### PR TITLE
Don't confuse user with fakeresponse

### DIFF
--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -369,7 +369,8 @@ class WorkUnitGenerator(object):
 
             elif isinstance(r, FakeResponse):
                 self.queue.push(batch)
-                self._ui.debug('Skipping processing response because of FakeResponse')
+                self._ui.debug('Skipping processing response '
+                               'because of FakeResponse')
             else:
                 try:
                     self._ui.warning('batch {} failed with status: {}'

--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -24,7 +24,7 @@ from six.moves import zip
 import requests
 import six
 
-from .network import Network
+from .network import Network, FakeResponse
 from .utils import acquire_api_token, iter_chunks, auto_sampler, Recoder, \
     investigate_encoding_and_dialect
 
@@ -366,6 +366,10 @@ class WorkUnitGenerator(object):
                                                self.pred_name)
                 except Exception as e:
                     self._ui.fatal('{} response error: {}'.format(batch.id, e))
+
+            elif isinstance(r, FakeResponse):
+                self.queue.push(batch)
+                self._ui.debug('Skipping processing response because of FakeResponse')
             else:
                 try:
                     self._ui.warning('batch {} failed with status: {}'
@@ -749,7 +753,7 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
                               lid, keep_cols, n_retry, delimiter,
                               dataset, pred_name, ui, fast_mode,
                               encoding))
-        network = stack.enter_context(Network(concurrent, timeout))
+        network = stack.enter_context(Network(concurrent, timeout, ui))
         n_batches_checkpointed_init = len(ctx.db['checkpoints'])
         ui.debug('number of batches checkpointed initially: {}'
                  .format(n_batches_checkpointed_init))

--- a/datarobot_batch_scoring/network.py
+++ b/datarobot_batch_scoring/network.py
@@ -1,7 +1,8 @@
 import collections
 import logging
-
+import textwrap
 import gc
+
 import requests
 
 try:
@@ -29,13 +30,12 @@ class Network(object):
         try:
             self.session.send(prepared, timeout=self._timeout)
         except requests.exceptions.ReadTimeout:
-            self._ui.warning("""
-                The server did not send any data
-                in the allotted amount of time.
-                You might want to increase --timeout parameter
-                or
-                decrease --n_samples --n_concurrent parameters
-            """)
+            self._ui.warning(textwrap.dedent("""The server did not send any data
+in the allotted amount of time.
+You might want to increase --timeout parameter
+or
+decrease --n_samples --n_concurrent parameters
+"""))
 
         except Exception as exc:
             self._ui.debug('Exception {}: {}'.format(type(exc), exc))

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,50 @@
+import mock
+import textwrap
+
+import requests
+
+from datarobot_batch_scoring.batch_scoring import run_batch_predictions
+
+
+def test_request_client_timeout(live_server, tmpdir):
+    out = tmpdir.join('out.csv')
+    ui = mock.Mock()
+    base_url = '{webhost}/api/v1/'.format(webhost=live_server.url())
+    with mock.patch('datarobot_batch_scoring.'
+                    'network.requests.Session') as nw_mock:
+        nw_mock.return_value.send = mock.Mock(
+            side_effect=requests.exceptions.ReadTimeout)
+
+        ret = run_batch_predictions(
+            base_url=base_url,
+            base_headers={},
+            user='username',
+            pwd='password',
+            api_token=None,
+            create_api_token=False,
+            pid='56dd9570018e213242dfa93c',
+            lid='56dd9570018e213242dfa93d',
+            n_retry=3,
+            concurrent=1,
+            resume=False,
+            n_samples=10,
+            out_file=str(out),
+            keep_cols=None,
+            delimiter=None,
+            dataset='tests/fixtures/temperatura_predict.csv.gz',
+            pred_name=None,
+            timeout=30,
+            ui=ui,
+            auto_sample=False,
+            fast_mode=False,
+        )
+
+    assert ret is None
+    returned = out.read_text('utf-8')
+    assert '' in returned, returned
+    ui.warning.assert_called_with(textwrap.dedent("""The server did not send any data
+in the allotted amount of time.
+You might want to increase --timeout parameter
+or
+decrease --n_samples --n_concurrent parameters
+"""))


### PR DESCRIPTION
When requests raising ReadTimeoutError, we're crafting FakeResponse and
processing it. Instead of processing it's like 400 response we should
raise information that batch was dropped because server was responding
too long