### PR TITLE
use a lower default compression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 * added 3rd parallel process which handles post-processing and writing of responses.
   This should greatly improve performance.
 
+* add ability to compress data in transit
+
 1.8.8 (2016 November 17)
 ==================
 * --output_delimiter flag to set delimiter for output CSV. "tab" can be used 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ flake8: .install-test-deps
 	touch .install
 
 test: .install .install-test-deps flake8
+	# test that we can make the HTML for pypi. 1(info) might be too strict
+	rst2html.py --report=1 --exit-status=1 README.rst > /dev/null
 	py.test -v tests/
 
 cov cover coverage: .install .install-test-deps flake8

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ The following table describes each of the arguments:
 
 Example::
 
-  batch_scoring --host=https://beta.datarobot.com/ --user="greg@datarobot.com" --out=pred.csv 5545eb20b4912911244d4835 5545eb71b4912911244d4847 ~/Downloads/diabetes_test.csv
+    batch_scoring --host=https://mycorp.orm.datarobot.com/ --user="greg@mycorp.com" --out=pred.csv 5545eb20b4912911244d4835 5545eb71b4912911244d4847 /home/greg/Downloads/diabetes_test.csv
 
 
 Using configuration file
@@ -118,11 +118,14 @@ The format of a `batch_scoring.ini` file is as follows::
 
 
 Usage Notes
-------------
+-----------
   * If the script detects that a previous script was interrupted in mid-execution, it will prompt whether to resume that execution.
   * If no interrupted script was detected or if you indicate not to resume the previous execution, the script checks to see if the specified output file exists. If yes, the script prompts to confirm before overwriting this file.
   * The logs from each batch_scoring run are stored in the current working. All users will see a `datarobot_batch_scoring_main.log` log file. Windows users will see two additional log file, `datarobot_batch_scoring_batcher.log` and `datarobot_batch_scoring_writer.log`.
 
+
 Supported Platforms
-------------
+-------------------
 The batch_scoring script is tested on Linux and Windows, but it should also work on OS X. Both Python 2.7 and Python 3.x are supported.
+
+

--- a/README.rst
+++ b/README.rst
@@ -1,30 +1,28 @@
-DataRobot batch_scoring
+datarobot_batch_scoring
 =======================
 
 A script to score CSV files via DataRobot's prediction API.
 
 .. image:: https://coveralls.io/repos/github/datarobot/batch-scoring/badge.svg?branch=master
-   :target: https://coveralls.io/github/datarobot/batch-scoring?branch=master
+    :target: https://coveralls.io/github/datarobot/batch-scoring?branch=master
 
 .. image:: https://travis-ci.org/datarobot/batch-scoring.svg?branch=master
-   :target: https://travis-ci.org/datarobot/batch-scoring#master
+    :target: https://travis-ci.org/datarobot/batch-scoring#master
 
 .. image:: https://caniusepython3.com/project/datarobot_batch_scoring.svg
 
 .. image:: https://badge.fury.io/py/datarobot_batch_scoring.svg
-   :target: https://badge.fury.io/py/datarobot_batch_scoring.svg
+    :target: https://badge.fury.io/py/datarobot_batch_scoring.svg
 
 
 How to install
 --------------
 
-Install or upgrade to last version:
-::
+Install or upgrade to last version: ::
 
     $ pip install -U datarobot_batch_scoring
 
-How to install particular version:
-::
+How to install particular version: ::
 
     $ pip install datarobot_batch_scoring==x.y.z
 

--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -65,7 +65,7 @@ class TargetType(object):
 
 def compress(data):
     buf = io.BytesIO()
-    with GzipFile(fileobj=buf, mode='wb') as f:
+    with GzipFile(fileobj=buf, mode='wb', compresslevel=2) as f:
         f.write(data)
     return buf.getvalue()
 

--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -599,13 +599,13 @@ class WorkUnitGenerator(object):
                 if starting_size < self.max_batch_size:
                     if self.compression:
                         data = compress(data)
-                        self._ui.debug('batch {}-{} transmitting {} byte - '
-                                       'space savings {}%'
-                                       ''.format(batch.id, batch.rows,
-                                                 sys.getsizeof(data),
-                                                 "%.2f" % float(1 -
-                                                 (sys.getsizeof(data) /
-                                                  starting_size))))
+                        self._ui.debug(
+                            'batch {}-{} transmitting {} byte - space savings '
+                            '{}%'.format(batch.id, batch.rows,
+                                         sys.getsizeof(data),
+                                         '%.2f' % float(1 -
+                                                        (sys.getsizeof(data) /
+                                                         starting_size))))
                     else:
                         self._ui.debug('batch {}-{} transmitting {} bytes'
                                        .format(batch.id, batch.rows,

--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -599,13 +599,13 @@ class WorkUnitGenerator(object):
                 if starting_size < self.max_batch_size:
                     if self.compression:
                         data = compress(data)
-
                         self._ui.debug('batch {}-{} transmitting {} byte - '
-                                       'compression ratio {}%'
+                                       'space savings {}%'
                                        ''.format(batch.id, batch.rows,
                                                  sys.getsizeof(data),
-                                                 int(sys.getsizeof(data) /
-                                                     starting_size * 100)))
+                                                 "%.2f" % float(1 -
+                                                 (sys.getsizeof(data) /
+                                                  starting_size))))
                     else:
                         self._ui.debug('batch {}-{} transmitting {} bytes'
                                        .format(batch.id, batch.rows,
@@ -1182,6 +1182,7 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
             ui.info('dry-run complete | time elapsed {}s'.format(time() - t0))
             ui.info('dry-run complete | total time elapsed {}s'.format(
                 time() - t1))
+            ctx.scoring_succeeded = True
         else:
             for r in network.perform_requests(work_unit_gen):
                 if r is True:


### PR DESCRIPTION
This compresslevel has a more reasonable trade off between time and space savings. We also now log space savings instead of compression ratio.

I also clean up context if it's a dry_run

@Axik @sevikkk 