### PR TITLE
Offline Install Options 

### DIFF
--- a/DEV_README.rst
+++ b/DEV_README.rst
@@ -48,18 +48,35 @@ Cut a release candidate
 Travis bot runs automated tests and publish new version on PyPI when
 tests are passed.
 
+
+Offline Bundle
+--------------
+
+``make offlinebundle`` will create a zip file containing:
+
+  - helper_packages/ - packages like pip and virtualenv which can be used offline
+  - required_packages/ - the batch_scoring script and its dependencies
+  - OFFLINE_INSTALL_README.txt - install instructions 
+  - get-pip.py - a script that allows us to bootstrap pip in user mode
+
+This offline install method is suitable in situations where Python 2.7 or Python 3 
+are available. ``sudo`` is not required.
+
+
 PyInstaller single-file executable - experimental
 -------------------------------------------------
 
 `See an overview of PyInstaller here <http://pyinstaller.readthedocs.io/en/stable/operating-mode.html>`_
 
-This is still experimental, but it seems to work on linux. PyInstaller bundles
+This is still experimental, but it seems to work on linux and OSX. PyInstaller bundles
 all the code and dependencies, including the Python interpreter, into a single
 directory or executable file. Right now we are creating two single-file
 executables; batch_scoring_sse and batch_scoring.
 
-To create the installs, activate a virtualenv, preferably with python3, and
-run ``make pyinstaller``.  The executables will be placed in ``./dist/``.
+The requirements for building are virtualenv and python3.4+. Python 2.7 
+should work, but we don't want to ship that at this point. 
+To build, run ``make pyinstaller``. The executables will be placed in 
+``./dist/datarobot_batch_scoring_x.y.z_executables.zip``.
 
 This is considered experimental because it's untested, and may not work on every platform
 we need to support. For example, we need to be careful that linux apps are

--- a/DEV_README.rst
+++ b/DEV_README.rst
@@ -49,7 +49,7 @@ Travis bot runs automated tests and publish new version on PyPI when
 tests are passed.
 
 PyInstaller single-file executable - experimental
----------------------
+-------------------------------------------------
 
 `See an overview of PyInstaller here <http://pyinstaller.readthedocs.io/en/stable/operating-mode.html>`_
 
@@ -62,8 +62,8 @@ To create the installs, activate a virtualenv, preferably with python3, and
 run ``make pyinstaller``.  The executables will be placed in ``./dist/``.
 
 This is considered experimental because it's untested, and may not work on every platform
-we need to support. For example, we need to be careful about
-`linux apps forward compatible<http://pyinstaller.readthedocs.io/en/stable/usage.html#making-linux-apps-forward-compatible>`_
-, and we would need separate builds for
-`OSX and Windows<http://pyinstaller.readthedocs.io/en/stable/usage.html#supporting-multiple-operating-systems>`_
-.
+we need to support. For example, we need to be careful that linux apps are
+forward compatible_, and we would need separate builds_ for OSX and Windows.
+
+.. _compatible: http://pyinstaller.readthedocs.io/en/stable/usage.html#making-linux-apps-forward-compatible
+.. _builds: http://pyinstaller.readthedocs.io/en/stable/usage.html#supporting-multiple-operating-systems

--- a/DEV_README.rst
+++ b/DEV_README.rst
@@ -48,13 +48,22 @@ Cut a release candidate
 Travis bot runs automated tests and publish new version on PyPI when
 tests are passed.
 
-Packaging for windows
+PyInstaller single-file executable - experimental
 ---------------------
-Use Python 3.4 only -- py2exe doesn't work with Python 3.5:
 
-1. install py2exe (pip install py2exe)
-2. install requirements (pip install -r requirements34.txt)
-3. build dist (python setup.py py2exe)
-4. Distribute content of *dist* folder
-5. On target machine download "Microsoft Visual C++ 2010 Redistributable Package (x64)" (https://www.microsoft.com/en-us/download/details.aspx?id=14632) and install
-6. Enjoy!
+`See an overview of PyInstaller here <http://pyinstaller.readthedocs.io/en/stable/operating-mode.html>`_
+
+This is still experimental, but it seems to work on linux. PyInstaller bundles
+all the code and dependencies, including the Python interpreter, into a single
+directory or executable file. Right now we are creating two single-file
+executables; batch_scoring_sse and batch_scoring.
+
+To create the installs, activate a virtualenv, preferably with python3, and
+run ``make pyinstaller``.  The executables will be placed in ``./dist/``.
+
+This is considered experimental because it's untested, and may not work on every platform
+we need to support. For example, we need to be careful about
+`linux apps forward compatible<http://pyinstaller.readthedocs.io/en/stable/usage.html#making-linux-apps-forward-compatible>`_
+, and we would need separate builds for
+`OSX and Windows<http://pyinstaller.readthedocs.io/en/stable/usage.html#supporting-multiple-operating-systems>`_
+.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION := $(shell python -c 'from datarobot_batch_scoring.__init__ import __version__ as v ; print(v)')
+export VERSION
 .PHONY: test
 
 .install-test-deps: requirements-test.txt
@@ -22,15 +24,47 @@ cov cover coverage: .install .install-test-deps flake8
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 pyinstaller: clean
-	pip uninstall -y datarobot_batch_scoring || true
-	pip install -r requirements.txt -r requirements-test.txt
-	pyinstaller -y --onefile -n batch_scoring batch_scoring.py
-	pyinstaller -y --onefile -n batch_scoring_sse batch_scoring_sse.py
+	rm -rf dist/pyinstaller dist/datarobot_batch_scoring_*_executables
+	mkdir -p dist/pyinstaller
+	cp OFFLINE_INSTALL_README.txt dist/pyinstaller
+	( \
+		PYTHON=`which python3.5 || which python3.4 || which python` ; \
+		virtualenv --python="$${PYTHON}" TEMPVENV ; \
+		. ./TEMPVENV/bin/activate; \
+		pip install -U pip ; \
+		pip install -r requirements.txt -r requirements-test.txt ; \
+		pip install -U urllib3[secure] ; \
+		pyinstaller -y --distpath=dist/pyinstaller --onefile -n batch_scoring batch_scoring.py ; \
+		pyinstaller -y --distpath=dist/pyinstaller --onefile -n batch_scoring_sse batch_scoring_sse.py ; \
+		cd dist/; \
+		mv pyinstaller datarobot_batch_scoring_"$${VERSION}"_executables; \
+		zip -r -0 datarobot_batch_scoring_"$${VERSION}"_executables.zip datarobot_batch_scoring_"$${VERSION}"_executables; \
+	)
+
+offlinebundle:
+	@rm -rf ./TEMPVENV ./dist/offlinebundle
+	@mkdir -p dist/offlinebundle/required_packages dist/offlinebundle/helper_packages
+	@cp OFFLINE_INSTALL_README.txt dist/offlinebundle/
+	wget https://bootstrap.pypa.io/get-pip.py
+	@mv get-pip.py dist/offlinebundle/
+	( \
+		virtualenv TEMPVENV; \
+		. ./TEMPVENV/bin/activate; \
+		pip install -U pip setuptools; \
+		python setup.py sdist; \
+		pip download --dest=dist/offlinebundle/helper_packages --no-cache-dir  \
+						pip setuptools virtualenv virtualenvwrapper wheel appdirs \
+						pyparsing six packaging ; \
+		pip download --dest=dist/offlinebundle/required_packages --no-cache-dir --no-binary :all: \
+						dist/datarobot_batch_scoring-"$${VERSION}".tar.gz; \
+		cd ./dist ; \
+		zip -r -0 datarobot_batch_scoring_"$${VERSION}"_offlinebundle.zip offlinebundle ; \
+	)
 
 clean:
 	@rm -rf .install
 	@rm -rf .install-test-deps
-	@rm -rf datarobot_batch_scoring.egg-info build/* dist/*
+	@rm -rf datarobot_batch_scoring.egg-info build/* dist/* ./TEMPVENV
 	@rm -rf htmlcov
 	@rm -rf .coverage
 	@find . -name __pycache__ | xargs rm -rf

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,16 @@ cov cover coverage: .install .install-test-deps flake8
             --cov-report=term --cov-report=html tests/
 	@echo "open file://`pwd`/htmlcov/index.html"
 
+pyinstaller: clean
+	pip uninstall -y datarobot_batch_scoring || true
+	pip install -r requirements.txt -r requirements-test.txt
+	pyinstaller -y --onefile -n batch_scoring batch_scoring.py
+	pyinstaller -y --onefile -n batch_scoring_sse batch_scoring_sse.py
+
 clean:
 	@rm -rf .install
 	@rm -rf .install-test-deps
-	@rm -rf datarobot_batch_scoring.egg-info
+	@rm -rf datarobot_batch_scoring.egg-info build/* dist/*
 	@rm -rf htmlcov
 	@rm -rf .coverage
 	@find . -name __pycache__ | xargs rm -rf

--- a/OFFLINE_INSTALL_README.txt
+++ b/OFFLINE_INSTALL_README.txt
@@ -1,0 +1,62 @@
+# These directions are for the offline install 
+
+# There are two methods of offline install
+  1. a zip file containing all the packages needed to install pip 
+     and batch_scoring for an unprivalaged offline user
+  2. a single-file executable made by PyInstaller that only depends on 
+     libc.
+
+
+
+1. Instructions - Install batch_scoring using pip for an unprivilaged user
+
+# you need a zip file that has a name like 
+#    datarobot_batch_scoring_1.10.0_offlinebundle.zip
+# you must have python 2.7 or python 3 installed but pip is NOT required
+
+# unzip the offlinebundle zip file and change directory into offlinebundle
+# run the following command to install pip in --user mode
+
+python get-pip.py --user --no-index --find-links=helper_packages/
+
+# then install all of the helper packages which you may want to use
+python -m pip install --user --no-index --find-links=helper_packages/ helper_packages/*
+
+# This will install pip and a few other commands in ~/.local/bin 
+# but that directory must be added to your path before you can use them
+# On Linux this can be done by appending the following line to your user's ~/.bashrc
+# On windows or OSX this will look different
+
+export PATH=~/.local/bin/:$PATH
+
+# then source the file if on Linux
+source ~/.bashrc
+
+# Now the user will always be able to use the commands:
+pip --version
+> pip 9.0.1 from /home/user/.local/lib/python2.7/site-packages (python 2.7)
+
+# at this point we could create and use a virtualenv if we wanted to. If you 
+# know what you are doing and want to use a virtualenv, go right ahead. 
+# That being said, it might be easier for the user if they don't need to know 
+# about virtualenvs so in the case we are installing it in --user mode. 
+
+pip install --user --no-index --find-links=required_packages/ required_packages/* 
+
+# test it out 
+
+batch_scoring --version
+
+
+
+2. Instructions - install single-file executable
+
+# The single-file executable is easy to install, but it will fail if it isn't made correctly.
+# Each executable must be built for the OS and OS version it will run on, so make 
+# sure you communicate that information. 
+
+# Once you have the executable, place it on the user's path. test them out by running
+# them on the command line
+
+batch_scoring --version
+batch_scoring_sse --version

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,7 @@ Supported Platforms
 The batch_scoring script is tested on Linux and Windows, but it should also work on OS X. Both Python 2.7 and Python 3.x are supported.
 
 Recommended Platform
--------------------
-Python 3 is recommended over Python 2 because Python 3 seems to handle encoding errors more gracefully. Python 3 also performs better.
+--------------------
+Python 3.x is recommended over Python 2.7.x. Python 2 sometimes errors decoding datasets
+that Python 3.x handles gracefully. Python 3 is also faster.
 

--- a/README.rst
+++ b/README.rst
@@ -140,4 +140,7 @@ Supported Platforms
 -------------------
 The batch_scoring script is tested on Linux and Windows, but it should also work on OS X. Both Python 2.7 and Python 3.x are supported.
 
+Recommended Platform
+-------------------
+Python 3 is recommended over Python 2 because Python 3 seems to handle encoding errors more gracefully. Python 3 also performs better.
 

--- a/batch_scoring_sse.py
+++ b/batch_scoring_sse.py
@@ -1,4 +1,4 @@
 from datarobot_batch_scoring import main
 # This exists as a simple entrypoint for PyInstaller
 
-main.main()
+main.main_standalone()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,3 +6,4 @@ pytest-flake8==0.1
 pymongo==2.8
 Flask==0.10.1
 mock>=1.3.0
+PyInstaller==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -2,29 +2,22 @@
 import codecs
 import os.path
 import re
-import sys
+from setuptools import setup
 
 extra = {}
 
-if 'py2exe' in sys.argv:
-    import py2exe
-    from distutils.core import setup
-    extra['console'] = ['batch_scoring.py']
-else:
-    py2exe = None
-    from setuptools import setup
 
-    fname = os.path.join(os.path.abspath(os.path.dirname(
-        __file__)), 'requirements.txt')
+fname = os.path.join(os.path.abspath(os.path.dirname(
+    __file__)), 'requirements.txt')
 
-    install_requires = open(fname, 'r').readlines()
+install_requires = open(fname, 'r').readlines()
 
-    extra['entry_points'] = {
-        'console_scripts': [
-            'batch_scoring = datarobot_batch_scoring.main:main',
-            'batch_scoring_sse = datarobot_batch_scoring.main:main_standalone'
-        ]}
-    extra['install_requires'] = install_requires
+extra['entry_points'] = {
+    'console_scripts': [
+        'batch_scoring = datarobot_batch_scoring.main:main',
+        'batch_scoring_sse = datarobot_batch_scoring.main:main_standalone'
+    ]}
+extra['install_requires'] = install_requires
 
 
 fname = os.path.join(os.path.abspath(os.path.dirname(


### PR DESCRIPTION
Read the DEV_README for details on how the two offline install options are built. 

The OFFLINE_INSTALL_README is zipped up with the builds and explains how to perform the offline install.

You can see the pip-based offline install in action using docker containers with no network access with these steps:

make a build and start the container:
```
make offlinebundle

docker run --network=none --rm -it -v ~/workspace/batch-scoring:/batch-scoring centos:7 bash
``` 
Run this inside the container
```
useradd -m --shell=/bin/bash -u 1001 user 
su user 
cp -r /batch-scoring/dist/offlinebundle ~/
cd ~/offlinebundle
python get-pip.py --user --no-index --find-links=helper_packages/
echo 'export PATH=~/.local/bin/:$PATH' >> ~/.bashrc
source ~/.bashrc
pip install --user --no-index --find-links=helper_packages/ helper_packages/*   #    Note these must all be wheels or it will fail
pip install --user --no-index --find-links=required_packages/ required_packages/*     # don't need to be wheels
batch_scoring --version
```

The pip-based offline install works but it is probably not optimal. I don't claim to understand everything about Python packaging and so there is probably room for improvement. I'm mainly concerned about compatibility between platforms because of our reliance on wheels.   Does anyone know a better way to bootstrap a non-privileged? 

The fall-back for when the pip-based install approach fails is the single-file-executable made by PyInstalled. This works pretty well for a stand-alone program like batch-scoring, and it is very simple for the user, but it's not a solution for a lib like the public-api package. 

You can try the single-file executable in docker with:
```
make pyinstaller
docker run --network=none --rm -it -v ~/workspace/batch-scoring:/batch-scoring centos:7 bash
``` 
inside the container
```
useradd -m --shell=/bin/bash -u 1001 user 
su user 
cp -r /batch-scoring/dist/datarobot_batch_scoring_1.10.0_executables ~/
cd ~/datarobot_batch_scoring_1.10.0_executables
./batch_scoring --help
./batch_scoring_sse --help
```


I made the bundles using `zip` for the sake of Windows users, but it doesn't seem like `unzip` comes by default on most Linux distros. I'm not sure what the most universal option would be. If we use `tar` it will be more difficult for Windows users.  






