### PR TITLE
Refactor offlinebundle/pyinstaller for limited release

### DIFF
--- a/BATCH_SCORING_EXECUTABLE_README.txt
+++ b/BATCH_SCORING_EXECUTABLE_README.txt
@@ -1,0 +1,28 @@
+# These directions are for installing the datarobot_batch_scoring executable 
+
+# Linux / OSX users
+
+# 1. Unzip or untar the executables 
+
+  unzip datarobot_batch_scoring_*_executables.Linux.x86_64.zip    # for zip
+  tar -xf datarobot_batch_scoring_*_executables.Linux.x86_64.tar  # for tar 
+
+
+# 2. Install 
+  # 2.A   Install as normal user without sudo
+
+    # if you don't have sudo or want to install as a normal user, follow these directions
+    # Skip to 2.B if you want to install with sudo 
+  
+    mkdir -p ~/bin/                                        # make bin dir for user
+    cp datarobot_batch_scoring_*/batch_scoring* ~/bin/     # copy to bin dir
+    echo 'export PATH=$PATH:~/bin' >> ~/.bashrc            # add bin to path
+    source ~/.bashrc                                       # source path
+    batch_scoring --help                                   # test that it worked
+
+  # 2.B   Install with sudo
+    
+    sudo cp datarobot_batch_scoring_*/batch_scoring* /bin/ # copy to bin directory
+    batch_scoring --help                                   # test that it worked
+
+

--- a/DEV_README.rst
+++ b/DEV_README.rst
@@ -35,48 +35,72 @@ Run batch-scoring from container::
     $ docker-compose run python27 batch-scoring {args..}
     $ docker-compose run python35 batch-scoring {args..}
 
-Deployment
-----------
+Release 
+-------
 
-Cut a release candidate
+1. update ``__version__`` in ``datarobot_batch_scoring/__init__.py``
+2. perform acceptance tests
+3. tag release
+4. push a tag to GitHub
 
-  - update ``__version__`` in ``datarobot_batch_scoring/__init__.py``
-  - perform acceptance tests
-  - tag release
-  - push a tag to GitHub
-
-Travis bot runs automated tests and publish new version on PyPI when
-tests are passed.
+  Travis bot runs automated tests and publish new version on PyPI when  
+  tests are passed.
+5. build the **PyInstaller** and **Offlinebundle** for Linux.
+  1. build the image for PyInstaller with ``docker-compose build centos5pyinstaller``
+  2. build both releases with ``make build_release_dockerized``
+6. upload the builds producted by step 5. 
+  1. find the release page for the version that was pushed at https://github.com/datarobot/batch-scoring/releases
+  2. ``edit`` the release on github and attach the 4 files (2 zips, 2 tars) that were created in the **batch-scoring/dist** dir. ``save`` changes.
 
 
 Offline Bundle
 --------------
+This is a bundle which allows users to install datarobot_batch_scoring offline using the existing Python2.7 or 
+Python3+ on the system. It includes all the dependencies and a script for bootstraps ``pip``.
 
-``make offlinebundle`` will create a zip file containing:
-
+We will release this on our Github release page. The archive contains:
   - helper_packages/ - packages like pip and virtualenv which can be used offline
   - required_packages/ - the batch_scoring script and its dependencies
   - OFFLINE_INSTALL_README.txt - install instructions 
   - get-pip.py - a script that allows us to bootstrap pip in user mode
 
-This offline install method is suitable in situations where Python 2.7 or Python 3 
-are available. ``sudo`` is not required.
+This offline install method is suitable in situations where  Python 2.7 or Python 3+ are available. 
+``sudo`` is not required.
 
 
-PyInstaller single-file executable - experimental
--------------------------------------------------
+PyInstaller single-file executable
+----------------------------------
 
 `See an overview of PyInstaller here <http://pyinstaller.readthedocs.io/en/stable/operating-mode.html>`_
 
-This is still experimental, but it seems to work on linux and OSX. PyInstaller bundles
-all the code and dependencies, including the Python interpreter, into a single
+PyInstaller bundles all the code and dependencies, including the Python interpreter, into a single 
 directory or executable file. Right now we are creating two single-file
-executables; batch_scoring_sse and batch_scoring.
+executables; ``batch_scoring_sse`` and ``batch_scoring``.
 
-The requirements for building are virtualenv and python3.4+. Python 2.7 
-should work, but we don't want to ship that at this point. 
-To build, run ``make pyinstaller``. The executables will be placed in 
-``./dist/datarobot_batch_scoring_x.y.z_executables.zip``.
+We make a special image just for building this executable. 
+
+**PyInstaller build instructions - Linux**
+
+  **Dependencies:** Docker, docker-compose, Make
+
+    1. build the image for PyInstaller with ``docker-compose build centos5pyinstaller``
+    2. build just the pyinstaller executables with ``make pyinstaller_dockerized``. See the **Release** section of this readme for the official release process.
+
+**PyInstaller build instructions - OSX / Other nixes**
+
+  **Dependencies:** Make, Python>=3.4, zip
+
+  TODO: formalize build/release/testing process
+
+  The build works but we aren't ready to release. Dev builds can be made with ``make pyinstaller``
+
+**PyInstaller build instructions - Windows**
+
+  TODO: This should work but we don't have a build or release process for it yet.
+
+
+The executables will be placed in 
+``./dist/datarobot_batch_scoring_<version>_executables.<platform>.<arch>``.
 
 This is considered experimental because it's untested, and may not work on every platform
 we need to support. For example, we need to be careful that linux apps are

--- a/Dockerfile-pyinstaller-centos5-py35-build
+++ b/Dockerfile-pyinstaller-centos5-py35-build
@@ -1,9 +1,14 @@
 FROM quay.io/pypa/manylinux1_x86_64
-#  manylinux1 is being used because it is an ancient version of Centos with built tools
-#  we are building Python3.5 instead of using the one that already exists in the image 
-#  because they specifically remove libpython for wheelbuilding. 
+#
+#  This image is based on pypa/manylinux1 because they use an ancient version of Centos 
+#  which we want for ABI compatibility. 
+#
+#  We are building Python3.5 instead of using the one that already exists in the image 
+#  because pypa specifically remove libpython for wheelbuilding. See: 
 #  https://github.com/pypa/manylinux/blob/fe0967cf35b84fecb6ac3163074f1627356854e8/pep-513.rst#libpythonxyso1
+#
 #  pyinstaller requires libpython
+#
 #  http://www.pyinstaller.org/
 #  https://github.com/pypa/manylinux
 
@@ -12,7 +17,7 @@ ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
 ENV PYTHON_VERSION 3.5.3
 
 RUN set -ex \
-    && yum install -y gpg zip xz openssl-devel \
+    && yum install -y xz gpg zip openssl-devel zlib-devel bzip2-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel \
 	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
 	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
@@ -29,6 +34,8 @@ RUN set -ex \
 		--enable-shared \
 	&& make -j$(nproc) \
 	&& make install \
-	&& ldconfig 
+	&& ldconfig \
+	&& yum -y clean all > /dev/null 2>&1 \
+	&& ln -s /usr/local/bin/python3.5 /usr/local/bin/python
 
 CMD ["/bin/bash"]

--- a/Dockerfile-pyinstaller-centos5-py35-build
+++ b/Dockerfile-pyinstaller-centos5-py35-build
@@ -1,0 +1,34 @@
+FROM quay.io/pypa/manylinux1_x86_64
+#  manylinux1 is being used because it is an ancient version of Centos with built tools
+#  we are building Python3.5 instead of using the one that already exists in the image 
+#  because they specifically remove libpython for wheelbuilding. 
+#  https://github.com/pypa/manylinux/blob/fe0967cf35b84fecb6ac3163074f1627356854e8/pep-513.rst#libpythonxyso1
+#  pyinstaller requires libpython
+#  http://www.pyinstaller.org/
+#  https://github.com/pypa/manylinux
+
+ENV LANG C.UTF-8
+ENV GPG_KEY 97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+ENV PYTHON_VERSION 3.5.3
+
+RUN set -ex \
+    && yum install -y gpg zip xz openssl-devel \
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& rm -r "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar --use-compress-program=xz -xC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& ./configure \
+		--enable-loadable-sqlite-extensions \
+		--enable-shared \
+	&& make -j$(nproc) \
+	&& make install \
+	&& ldconfig 
+
+CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-VERSION := $(shell python -c 'from datarobot_batch_scoring.__init__ import __version__ as v ; print(v)')
 CDIR := $(shell pwd)
-export VERSION
 export CDIR
 .PHONY: test clean
 
@@ -26,55 +24,28 @@ cov cover coverage: .install .install-test-deps flake8
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 pyinstaller: clean
-	mkdir -p dist/pyinstaller
-	cp OFFLINE_INSTALL_README.txt dist/pyinstaller
-	( \
-		PYTHON=`which python3.5 || which python3` ; \
-		$${PYTHON} -m venv TEMPVENV ; \
-		. ./TEMPVENV/bin/activate ; \
-		pip install -U pip ; \
-		pip install -r requirements.txt -r requirements-test.txt ; \
-		pip install -U urllib3[secure] ; \
-		pyinstaller -y --distpath=dist/pyinstaller --onefile -n batch_scoring batch_scoring.py ; \
-		pyinstaller -y --distpath=dist/pyinstaller --onefile -n batch_scoring_sse batch_scoring_sse.py ; \
-		cd dist/; \
-		mv pyinstaller datarobot_batch_scoring_"$${VERSION}"_executables; \
-		zip -r -0 datarobot_batch_scoring_"$${VERSION}"_executables.zip datarobot_batch_scoring_"$${VERSION}"_executables; \
-	)
+	#  On Linux use "make pyinstaller_dockerized"
+	./offline_install_scripts/build_pyinstaller.sh
 
-pyinstaller_dockerized:
-	docker run --rm -it -v ${CDIR}:/batch-scoring pyinstaller-centos5-py35-build \
-		/batch-scoring/offline_install_scripts/build_pyinstall_dockerized.sh
+pyinstaller_dockerized: clean
+	docker run --rm -v ${CDIR}:/batch-scoring pyinstaller-centos5-py35-build \
+		/batch-scoring/offline_install_scripts/build_pyinstaller_dockerized.sh
 
 offlinebundle:
-	@rm -rf ./TEMPVENV ./dist/offlinebundle
-	@mkdir -p dist/offlinebundle/required_packages dist/offlinebundle/helper_packages
-	@cp OFFLINE_INSTALL_README.txt dist/offlinebundle/
-	wget https://bootstrap.pypa.io/get-pip.py
-	@mv get-pip.py dist/offlinebundle/
-	( \
-		python -m venv TEMPVENV; \
-		. ./TEMPVENV/bin/activate; \
-		pip install -U pip setuptools; \
-		python setup.py sdist; \
-		pip download --dest=dist/offlinebundle/helper_packages --no-cache-dir --only-binary :all: \
-						--implementation=py --abi=none --platform=any \
-						pip setuptools virtualenv virtualenvwrapper wheel appdirs \
-						pyparsing six packaging; \
-		pip download --dest=dist/offlinebundle/required_packages --no-cache-dir --no-binary :all: \
-						dist/datarobot_batch_scoring-"$${VERSION}".tar.gz; \
-		cd ./dist ; \
-		zip -r -0 datarobot_batch_scoring_"$${VERSION}"_offlinebundle.zip offlinebundle ; \
-	)
+	#  On Linux use "make offlinebundle_dockerized"
+	./offline_install_scripts/build_offlinebundle.sh
 
 offlinebundle_dockerized:
-	docker run --rm -it -v ${CDIR}:/batch-scoring python:3.5 \
+	docker run --rm -v ${CDIR}:/batch-scoring python:3.5 \
 		/batch-scoring/offline_install_scripts/build_offlinebundle_dockerized.sh
+
+build_release_dockerized: pyinstaller_dockerized offlinebundle_dockerized
 
 clean:
 	@rm -rf .install
 	@rm -rf .install-test-deps
-	@rm -rf datarobot_batch_scoring.egg-info build/* dist/* ./TEMPVENV
+	@rm -rf datarobot_batch_scoring.egg-info build/* dist/* 
 	@rm -rf htmlcov
 	@rm -rf .coverage
+	@rm -f batch_scoring.spec batch_scoring_sse.spec
 	@find . -name __pycache__ | xargs rm -rf

--- a/OFFLINEBUNDLE_INSTALL_README.txt
+++ b/OFFLINEBUNDLE_INSTALL_README.txt
@@ -1,21 +1,23 @@
-# These directions are for the offline install 
+# Instructions - Install batch_scoring using pip for an unprivilaged user
 
-# There are two methods of offline install
-  1. a zip file containing all the packages needed to install pip 
-     and batch_scoring for an unprivalaged offline user
-  2. a single-file executable made by PyInstaller that only depends on 
-     libc.
-
-
-
-1. Instructions - Install batch_scoring using pip for an unprivilaged user
+### Section 1 - unzip or untar the files
 
 # you need a zip file that has a name like 
 #    datarobot_batch_scoring_1.10.0_offlinebundle.zip
-# you must have python 2.7 or python 3 installed but pip is NOT required
+# you must have python 2.7 or python 3 installed, but pip is NOT required
 
 # unzip the offlinebundle zip file and change directory into offlinebundle
+# E.g. 
+
+unzip datarobot_batch_scoring_1.10.0_offlinebundle.zip
+cd datarobot_batch_scoring_1.10.0_offlinebundle
+
+### Section 2 - bootstrap pip
+
+# If you have pip, you can skip this section.
+
 # run the following command to install pip in --user mode
+# note you can use "python3" instead of "python" if that is an option
 
 python get-pip.py --user --no-index --find-links=helper_packages/
 
@@ -24,10 +26,10 @@ python -m pip install --user --no-index --find-links=helper_packages/ helper_pac
 
 # This will install pip and a few other commands in ~/.local/bin 
 # but that directory must be added to your path before you can use them
-# On Linux this can be done by appending the following line to your user's ~/.bashrc
-# On windows or OSX this will look different
+# On Linux this can be done by appending a line to your user's ~/.bashrc
+# 
 
-export PATH=~/.local/bin/:$PATH
+echo 'export PATH=$PATH:~/bin' >> ~/.bashrc 
 
 # then source the file if on Linux
 source ~/.bashrc
@@ -47,16 +49,3 @@ pip install --user --no-index --find-links=required_packages/ required_packages/
 
 batch_scoring --version
 
-
-
-2. Instructions - install single-file executable
-
-# The single-file executable is easy to install, but it will fail if it isn't made correctly.
-# Each executable must be built for the OS and OS version it will run on, so make 
-# sure you communicate that information. 
-
-# Once you have the executable, place it on the user's path. test them out by running
-# them on the command line
-
-batch_scoring --version
-batch_scoring_sse --version

--- a/README.rst
+++ b/README.rst
@@ -158,10 +158,10 @@ Usage Notes
 
 Supported Platforms
 -------------------
-The batch_scoring script is tested on Linux and Windows, but it should also work on OS X. Both Python 2.7 and Python 3.x are supported.
+datarobot_batch_scoring is tested on Linux and Windows and OS X. Both Python 2.7.x and Python 3.x are supported.
 
-Recommended Platform
---------------------
-Python 3.4+ is recommended over Python 2.7.x. Python 2 sometimes errors decoding datasets
+Recommended Python Version
+--------------------------
+Python 3.4 or greater is recommended, but all versions of Python 3 should work. Python 2.7.x. will work, but it sometimes errors decoding data
 that Python 3 handles gracefully. Python 3 is also faster.
 

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,26 @@ How to install particular version: ::
 
     $ pip install datarobot_batch_scoring==x.y.z
 
+Alternative Installs
+--------------------
+
+We publish two alternative install methods on our releases_ page. These are for situations where internet is restricted or Python is unavailable.
+
+:offlinebundle:
+    For performing installations in environments where Python2.7 or Python3+ is available, but there is no access to the internet.
+    Does not require administrative privileges or pip. Works on Linux, OSX or Windows.
+    
+    These files have "offlinebundle" in their name on the release page.
+
+:PyInstaller:
+    Using pyinstaller_ we build a single-file-executable that does not depend on Python. It only depends on libc and can be installed without administrative privileges.
+    Right now we publish builds that work for most Linux distros. Other NIX platforms (like OSX), and Windows are in the works.
+    
+    These files have "executables" in their name on the release page.
+
+.. _releases: https://github.com/datarobot/batch-scoring/releases
+.. _pyinstaller: http://www.pyinstaller.org/
+
 Features
 --------
 
@@ -142,6 +162,6 @@ The batch_scoring script is tested on Linux and Windows, but it should also work
 
 Recommended Platform
 --------------------
-Python 3.x is recommended over Python 2.7.x. Python 2 sometimes errors decoding datasets
-that Python 3.x handles gracefully. Python 3 is also faster.
+Python 3.4+ is recommended over Python 2.7.x. Python 2 sometimes errors decoding datasets
+that Python 3 handles gracefully. Python 3 is also faster.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,3 +43,9 @@ services:
         dockerfile: Dockerfile-2.7-dbg
      volumes:
         - .:/opt/project
+  centos5pyinstaller:
+     image: pyinstaller-centos5-py35-build
+     privileged: true
+     build:
+        context: .
+        dockerfile: Dockerfile-pyinstaller-centos5-py35-build

--- a/offline_install_scripts/build_offlinebundle.sh
+++ b/offline_install_scripts/build_offlinebundle.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Usage: invoked my "make offlinebundle_dockerized"
+# it is meant to run inside a docker container where it sets up the environment
+# it then calls the "make offlinebundle" build command
+set -e
+
+REPO_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+cd $REPO_BASE
+# venv as a module requires python3.4+
+PYTHON=`which python3.5 || which python3`
+
+rm -rf /tmp/TEMPVENV ./dist/offlinebundle
+$PYTHON -m venv /tmp/TEMPVENV
+. /tmp/TEMPVENV/bin/activate
+
+mkdir -p dist/offlinebundle/required_packages dist/offlinebundle/helper_packages
+cp OFFLINEBUNDLE_INSTALL_README.txt dist/offlinebundle/
+wget https://bootstrap.pypa.io/get-pip.py
+#  add documentation to zip
+mv get-pip.py dist/offlinebundle/
+
+pip install -U pip setuptools
+python setup.py sdist
+VERSION=$($PYTHON -c 'from datarobot_batch_scoring.__init__ import __version__ as v ; print(v)')
+pip download --dest=dist/offlinebundle/helper_packages --no-cache-dir --only-binary :all: \
+				--implementation=py --abi=none --platform=any \
+				pip setuptools virtualenv wheel appdirs \
+				pyparsing six packaging
+pip download --dest=dist/offlinebundle/required_packages --no-cache-dir --no-binary :all: \
+				dist/datarobot_batch_scoring-"${VERSION}".tar.gz
+rm dist/datarobot_batch_scoring-"${VERSION}".tar.gz
+cd ./dist
+zip -r -0 datarobot_batch_scoring_"${VERSION}"_offlinebundle.zip offlinebundle
+tar -cf datarobot_batch_scoring_"${VERSION}"_offlinebundle.tar offlinebundle

--- a/offline_install_scripts/build_offlinebundle_dockerized.sh
+++ b/offline_install_scripts/build_offlinebundle_dockerized.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 # Usage: invoked my "make offlinebundle_dockerized"
 # it is meant to run inside a docker container where it sets up the environment
-# it then calls the "make offlinebundle" build command
+# it then calls then runs build_offlinebundle.sh as user
 apt-get update
 apt-get install -y zip unzip -q
 HUID=`ls -nd /batch-scoring | cut --delimiter=' ' -f 3`
 useradd -m -s /bin/bash -u $HUID user 
-su user -c -l "cd /batch-scoring; make offlinebundle"
-exit
+su user -c -l "/batch-scoring/offline_install_scripts/build_offlinebundle.sh"

--- a/offline_install_scripts/build_offlinebundle_dockerized.sh
+++ b/offline_install_scripts/build_offlinebundle_dockerized.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Usage: invoked my "make offlinebundle_dockerized"
+# it is meant to run inside a docker container where it sets up the environment
+# it then calls the "make offlinebundle" build command
+apt-get update
+apt-get install -y zip unzip -q
+HUID=`ls -nd /batch-scoring | cut --delimiter=' ' -f 3`
+useradd -m -s /bin/bash -u $HUID user 
+su user -c -l "cd /batch-scoring; make offlinebundle"
+exit

--- a/offline_install_scripts/build_pyinstall_dockerized.sh
+++ b/offline_install_scripts/build_pyinstall_dockerized.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Usage: invoked my "make pyinstaller_dockerized"
+# it is meant to run inside a docker container where it sets up the environment
+# it then calls the "make pyinstaller" build command
+
+HUID=`ls -nd /batch-scoring | cut --delimiter=' ' -f 3`
+useradd -m -s /bin/bash -u $HUID user 
+# #  use python3.5 for the pyinstaller build
+echo 'export PATH=/usr/local/bin:$PATH' >> /home/user/.bashrc
+su user -c -l "cd /batch-scoring ; make pyinstaller"
+exit
+

--- a/offline_install_scripts/build_pyinstaller.sh
+++ b/offline_install_scripts/build_pyinstaller.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#  On Linux this should be run inside Docker and triggered by ./build_pyinstaller_dockerized.sh
+#  On OSX or other *nixes it would be run without docker
+set -e
+
+REPO_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+cd $REPO_BASE
+# venv as a module requires python3.4+
+PYTHON=`which python3.5 || which python3`
+rm -rf /tmp/TEMPVENV ./dist/pyinstaller
+
+$PYTHON -m venv /tmp/TEMPVENV
+. /tmp/TEMPVENV/bin/activate 
+
+mkdir -p dist/pyinstaller
+#  add documentation to zip
+cp BATCH_SCORING_EXECUTABLE_README.txt dist/pyinstaller
+
+pip install -U pip 
+pip install -U urllib3[secure]
+pip install -r requirements.txt -r requirements-pyinstaller.txt
+pyinstaller -y --distpath=dist/pyinstaller --onefile -n batch_scoring batch_scoring.py
+pyinstaller -y --distpath=dist/pyinstaller --onefile -n batch_scoring_sse batch_scoring_sse.py
+
+VERSION=$($PYTHON -c 'from datarobot_batch_scoring.__init__ import __version__ as v ; print(v)')
+PLATFORM=$($PYTHON -c 'import platform; print(platform.system())')
+ARCH=$($PYTHON -c 'import platform; print(platform.machine())')
+
+cd dist/
+NAME=datarobot_batch_scoring_"${VERSION}"_executables."${PLATFORM}"."${ARCH}"
+mv pyinstaller "${NAME}"
+zip -r -0 "${NAME}".zip "${NAME}"
+tar -cf "${NAME}".tar "${NAME}"

--- a/offline_install_scripts/build_pyinstaller_dockerized.sh
+++ b/offline_install_scripts/build_pyinstaller_dockerized.sh
@@ -7,6 +7,5 @@ HUID=`ls -nd /batch-scoring | cut --delimiter=' ' -f 3`
 useradd -m -s /bin/bash -u $HUID user 
 # #  use python3.5 for the pyinstaller build
 echo 'export PATH=/usr/local/bin:$PATH' >> /home/user/.bashrc
-su user -c -l "cd /batch-scoring ; make pyinstaller"
-exit
+su user -c -l "/batch-scoring/offline_install_scripts/build_pyinstaller.sh"
 

--- a/requirements-pyinstaller.txt
+++ b/requirements-pyinstaller.txt
@@ -1,0 +1,1 @@
+pyinstaller>=3.2,<4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,4 +6,4 @@ pytest-flake8==0.1
 pymongo==2.8
 Flask==0.10.1
 mock>=1.3.0
-PyInstaller==3.2.1
+pyinstaller>=3.2,<4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,4 +6,3 @@ pytest-flake8==0.1
 pymongo==2.8
 Flask==0.10.1
 mock>=1.3.0
-pyinstaller>=3.2,<4.0

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ with codecs.open(fname, 'r', 'latin1') as fp:
 setup(
     name='datarobot_batch_scoring',
     version=version,
-    description=("A script to support start/resume batch scoring "
-                 "via Datarobot API."),
+    description=("A script to score CSV files via DataRobot's prediction API"),
     author='DataRobot',
     author_email='support@datarobot.com',
     maintainer='DataRobot',


### PR DESCRIPTION
What this PR does / State of offline install : 
- Refactors method for building a `offlinebundle`. I moved a lot of this out of the Makefile because it just didn't make sense
  -  A lot of effort was made to ensure this works cross platform.  
  - Documentation is included in the bundle
- Refactors method for building a PyInstaller single-file-executable that should work on Linux distros newer than Centos5.
  - Shown to work on Linux and OSX, but we only have a Linux build and release process.
  - Documentation is included in the bundle
- added a dockerfile and docker-compose target for an image that will allow us to build a highly-compatible PyInstaller executable. This part is **super important** and took a large 
  portion of the time. See the comments in ``Dockerfile-pyinstaller-centos5-py35-build`` and ``DEV-README`` about  Pyinstaller.  
  - This is what should allow us to start publishing builds with some confidence. 
- I detailed a build + release process in ``DEV-README``. 
- Updates documentation to be user facing. 
- Uploaded the first releases here https://github.com/datarobot/batch-scoring/releases/tag/v1.10.0 

Not Done yet:
- Windows build
- OSX PyInstaller release. It should work but I have no idea what kind of compatibility issues there might be.  Honestly this doesn't matter as much because OSX comes with python2.7 so the offlinebundle should be a solution. 
- testing 
- Release automation. It is manual but doesn't take much time or effort
- an RPM or MSI package would be nice but this needs to come first.

Issues:
- The fact that ``batch_scoring_sse`` is a separate entrypoint basically doubles the size of the PyInstaller bundle unfortunately. 



