### PR TITLE
Cross-platform build and release process for single-file-executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,11 @@ script:
   - if [ $TRAVIS_OS_NAME == 'osx' ]; then ulimit -n 2048; fi
   - make cov
   - if [ $TRAVIS_OS_NAME != 'osx' ]; then python setup.py check -rms; fi
+  - pip install -r requirements-pyinstaller.txt
+  - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring batch_scoring.py
+  - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring_sse batch_scoring_sse.py
+  - dist/batch_scoring  --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032 --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024 tests/fictures/criteo_top30_1.5_MiB.csv.gz --dry_run --compress  -y
+  - dist/batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,42 +27,54 @@ matrix:
     - language: python
       python: 3.5
       os: linux
-
 install:
-  - if [ $TRAVIS_OS_NAME == 'osx' ]; then git clone https://github.com/MacPython/terryfy; source terryfy/travis_tools.sh; get_python_environment  $pydist $pyver; fi
-  - pip install -U pip wheel
-  - pip install -Ur requirements.txt
-  - pip install -Ur requirements-test.txt
-  - pip install coveralls
-
-
+- if [ $TRAVIS_OS_NAME == 'osx' ]; then git clone https://github.com/MacPython/terryfy;
+  source terryfy/travis_tools.sh; get_python_environment  $pydist $pyver; fi
+- pip install -U pip wheel
+- pip install -Ur requirements.txt
+- pip install -Ur requirements-test.txt
+- pip install coveralls
 script:
-  - if [ $TRAVIS_OS_NAME == 'osx' ]; then ulimit -n 2048; fi
-  - make cov
-  - if [ $TRAVIS_OS_NAME != 'osx' ]; then python setup.py check -rms; fi
-  - pip install -r requirements-pyinstaller.txt
-  - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring batch_scoring.py
-  - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring_sse batch_scoring_sse.py
-  - dist/batch_scoring  --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032 --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
-  - dist/batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
-
+- if [ $TRAVIS_OS_NAME == 'osx' ]; then ulimit -n 2048; fi
+- make cov
+- if [ $TRAVIS_OS_NAME != 'osx' ]; then python setup.py check -rms; fi
+- pip install -r requirements-pyinstaller.txt -U urllib3[secure]
+- pyinstaller -y --distpath=dist/ --onefile -n batch_scoring batch_scoring.py
+- pyinstaller -y --distpath=dist/ --onefile -n batch_scoring_sse batch_scoring_sse.py
+- dist/batch_scoring  --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032
+  --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024
+  tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
+- dist/batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz
+  --dry_run --compress  -y
 cache:
   directories:
-  - $HOME/.cache/pip
-
+  - "$HOME/.cache/pip"
 before_cache:
-  - rm -f $HOME/.cache/pip/log/debug.log
-
+- rm -f $HOME/.cache/pip/log/debug.log
 after_success:
-  - coveralls
-
+- coveralls
+- if [[ $TRAVIS_TAG ]]; then if [[ $pyver = '3.5' ]]; then ./offline_install_scripts/travis_pyinstaller_osx.sh $TRAVIS_TAG ; fi ; fi
 deploy:
-  provider: pypi
-  user: Axik
-  password:
-    secure: bn1C6OcsCyJ9jcEGusgyTHo4FS8SOrhVVtQpQVxolw8RJvQjSj666vuosG2r8DeIhhUrR9KV1Ee2A2HhSCkHCFw4fnIgsSXYLWj3DqbCdo9Qcs9raEevd2SDsNnxUjyfzm+0pQpqeA/La1+Pj94+CsSyJTlZSEepedtla/9zfJcIgJ/Z7g0rT7MLjBhGOf6ADepjtO5ZcmOIMaa/+iehZHtbfQJsjYfYIYQy/LJlX2MGFxMkUnyrnF/XuiK0tMTgeEvyOi8W6cDf3vIKHWp5f+mu8ZyyBcREeIkAgSzXvqrcta/m8kHGGRbjnS1tTORTudIUkUBtET+rUYiPRb3gFaEqLgjy0Pv5Nn34bSmAs2jEp92fzwFvOLNQhc0TKiwor1X2l6+MQvIwpRya64mke/DM3FLGknz/06q696iJEgQe1xw9Ju7dFX+IRcFsaR50jFrVsAxon51zvQ0gdgu8ztF9KU2IRTRp2qWXt7d96zyR340bwzjpgRB3QMy+2nMzOOjc0qvlI5tV77LWYA+eg/Knc2GiyMOByuygLQAjD1fxhANNDNLGItmKlAuknkuC0ovmALC9dRSwHQqO/v3eYA6nuHzdI1n3Z1LKjoUppm8RPZVNzX6EjCUGAYlmxCCEYIo7annRru/ZLWbjIc7duRZZL2sKKbwcg/qkC6bxDgo=
-  distributions: "sdist bdist_wheel"
-  on:
-    tags: true
-    all_branches: true
-    python: 3.5
+  - provider: releases
+    api_key:
+      secure: bL1mFfmelX+8c7lA8d3FFK988bq8N1mDGPVgQtx835dC+hTxpxaKwg1PaAp8hHv8IB8FnSypW9nRaqrPZ8mDHCeKNprMTm4/uxcN15nKp2oSMrSGCObpStlkz2bCRAFaxP2j+GcDjnFS5CLlJ3u1fYRqyHwGVR+4stxPBLMOpunPtmSG6qFucqfXP0xkDlIqjRu9OZexD2EgBGWo+gbBp01bNxSf50RUu1uvRhnKn16prBfW11NKiSZEwDQfjqKLxxztRT0ZACHGuWnw9cmZwo4RMK8JEmDVhv6PziKRZeCsr1sDhPF4AXigNBLDmIlvdDXR8vYkOKyKqcdcNTMfdjKFgZq/a8sG5+e/jcvOZqkvOUkUnkfInygpju+5iSylUYhpkG3DRvdzfZ9YRq3/kS82ZulTStkxB9SNDipYn5gAuLX7WaEu6JJ5cdHsmRsXhBNFR7cOWOwFH/4MNn8jdCBp96R5iXmji1qGH3QVrwvZL/d/jQc+72IPf0A/1lMK8OTEX0qb4kUZ75mSZYKHJRVN8XQQUQ2KMnqEPy/pLNJCqR9w5+KnSYBJmjh+0B6Zv14fq/GlNPEzUlXOSNmgVuOarGs+QvPT8gQSilw7v9G/mQxHINgqyF9ZYxmbDpyHIez1YvlU9bCDw2q7IZzpUfUNN8Y0VTtjwzRaZQuRKR8=
+    file: dist/datarobot_batch_scoring_"$TRAVIS_TAG"_executables.OSX.x86_64.tar
+    skip_cleanup: true
+    on:
+      repo: datarobot/batch-scoring
+      tags: true
+      all_branches: true
+      condition: $pyver = '3.5'
+
+## Commented for testing
+
+  # - provider: pypi
+  #   user: Axik
+  #   password: 
+  #     secure: bn1C6OcsCyJ9jcEGusgyTHo4FS8SOrhVVtQpQVxolw8RJvQjSj666vuosG2r8DeIhhUrR9KV1Ee2A2HhSCkHCFw4fnIgsSXYLWj3DqbCdo9Qcs9raEevd2SDsNnxUjyfzm+0pQpqeA/La1+Pj94+CsSyJTlZSEepedtla/9zfJcIgJ/Z7g0rT7MLjBhGOf6ADepjtO5ZcmOIMaa/+iehZHtbfQJsjYfYIYQy/LJlX2MGFxMkUnyrnF/XuiK0tMTgeEvyOi8W6cDf3vIKHWp5f+mu8ZyyBcREeIkAgSzXvqrcta/m8kHGGRbjnS1tTORTudIUkUBtET+rUYiPRb3gFaEqLgjy0Pv5Nn34bSmAs2jEp92fzwFvOLNQhc0TKiwor1X2l6+MQvIwpRya64mke/DM3FLGknz/06q696iJEgQe1xw9Ju7dFX+IRcFsaR50jFrVsAxon51zvQ0gdgu8ztF9KU2IRTRp2qWXt7d96zyR340bwzjpgRB3QMy+2nMzOOjc0qvlI5tV77LWYA+eg/Knc2GiyMOByuygLQAjD1fxhANNDNLGItmKlAuknkuC0ovmALC9dRSwHQqO/v3eYA6nuHzdI1n3Z1LKjoUppm8RPZVNzX6EjCUGAYlmxCCEYIo7annRru/ZLWbjIc7duRZZL2sKKbwcg/qkC6bxDgo=
+  #   distributions: sdist bdist_wheel
+  #   on:
+  #     repo: datarobot/batch-scoring
+  #     tags: true
+  #     all_branches: true
+  #     python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,16 +79,14 @@ deploy:
       all_branches: true 
       tags: false
       condition: $pyver = '3.5'
-
-## Commented for testing
-
-  # - provider: pypi
-  #   user: Axik
-  #   password: 
-  #     secure: bn1C6OcsCyJ9jcEGusgyTHo4FS8SOrhVVtQpQVxolw8RJvQjSj666vuosG2r8DeIhhUrR9KV1Ee2A2HhSCkHCFw4fnIgsSXYLWj3DqbCdo9Qcs9raEevd2SDsNnxUjyfzm+0pQpqeA/La1+Pj94+CsSyJTlZSEepedtla/9zfJcIgJ/Z7g0rT7MLjBhGOf6ADepjtO5ZcmOIMaa/+iehZHtbfQJsjYfYIYQy/LJlX2MGFxMkUnyrnF/XuiK0tMTgeEvyOi8W6cDf3vIKHWp5f+mu8ZyyBcREeIkAgSzXvqrcta/m8kHGGRbjnS1tTORTudIUkUBtET+rUYiPRb3gFaEqLgjy0Pv5Nn34bSmAs2jEp92fzwFvOLNQhc0TKiwor1X2l6+MQvIwpRya64mke/DM3FLGknz/06q696iJEgQe1xw9Ju7dFX+IRcFsaR50jFrVsAxon51zvQ0gdgu8ztF9KU2IRTRp2qWXt7d96zyR340bwzjpgRB3QMy+2nMzOOjc0qvlI5tV77LWYA+eg/Knc2GiyMOByuygLQAjD1fxhANNDNLGItmKlAuknkuC0ovmALC9dRSwHQqO/v3eYA6nuHzdI1n3Z1LKjoUppm8RPZVNzX6EjCUGAYlmxCCEYIo7annRru/ZLWbjIc7duRZZL2sKKbwcg/qkC6bxDgo=
-  #   distributions: sdist bdist_wheel
-  #   on:
-  #     repo: datarobot/batch-scoring
-  #     tags: true
-  #     all_branches: true
-  #     python: 3.5
+# PyPi Push on tag 
+  - provider: pypi
+    user: Axik
+    password: 
+      secure: bn1C6OcsCyJ9jcEGusgyTHo4FS8SOrhVVtQpQVxolw8RJvQjSj666vuosG2r8DeIhhUrR9KV1Ee2A2HhSCkHCFw4fnIgsSXYLWj3DqbCdo9Qcs9raEevd2SDsNnxUjyfzm+0pQpqeA/La1+Pj94+CsSyJTlZSEepedtla/9zfJcIgJ/Z7g0rT7MLjBhGOf6ADepjtO5ZcmOIMaa/+iehZHtbfQJsjYfYIYQy/LJlX2MGFxMkUnyrnF/XuiK0tMTgeEvyOi8W6cDf3vIKHWp5f+mu8ZyyBcREeIkAgSzXvqrcta/m8kHGGRbjnS1tTORTudIUkUBtET+rUYiPRb3gFaEqLgjy0Pv5Nn34bSmAs2jEp92fzwFvOLNQhc0TKiwor1X2l6+MQvIwpRya64mke/DM3FLGknz/06q696iJEgQe1xw9Ju7dFX+IRcFsaR50jFrVsAxon51zvQ0gdgu8ztF9KU2IRTRp2qWXt7d96zyR340bwzjpgRB3QMy+2nMzOOjc0qvlI5tV77LWYA+eg/Knc2GiyMOByuygLQAjD1fxhANNDNLGItmKlAuknkuC0ovmALC9dRSwHQqO/v3eYA6nuHzdI1n3Z1LKjoUppm8RPZVNzX6EjCUGAYlmxCCEYIo7annRru/ZLWbjIc7duRZZL2sKKbwcg/qkC6bxDgo=
+    distributions: sdist bdist_wheel
+    on:
+      repo: datarobot/batch-scoring
+      tags: true
+      all_branches: true
+      python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ deploy:
       secure: ***REMOVED***
     local_dir: dist/OSX
     bucket: batch-scoring-release-candidates
-    acl: ''
     upload-dir: osx-tagged-build
     on:
       repo: datarobot/batch-scoring
@@ -79,7 +78,6 @@ deploy:
       secure: ***REMOVED***
     local_dir: dist/OSX
     bucket: batch-scoring-release-candidates
-    acl: ''
     upload-dir: osx-dev-builds-not-for-release
     on:
       repo: datarobot/batch-scoring

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   - pip install -r requirements-pyinstaller.txt
   - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring batch_scoring.py
   - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring_sse batch_scoring_sse.py
-  - dist/batch_scoring  --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032 --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024 tests/fictures/criteo_top30_1.5_MiB.csv.gz --dry_run --compress  -y
+  - dist/batch_scoring  --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032 --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
   - dist/batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ matrix:
     python: 2.7
     os: linux
   - language: python
-    python: 3.3
-    os: linux
-  - language: python
     python: 3.4
     os: linux
   - language: python
@@ -41,11 +38,8 @@ script:
 - pip install -r requirements-pyinstaller.txt -U urllib3[secure]
 - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring batch_scoring.py
 - pyinstaller -y --distpath=dist/ --onefile -n batch_scoring_sse batch_scoring_sse.py
-- dist/batch_scoring  --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032
-  --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024
-  tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
-- dist/batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz
-  --dry_run --compress  -y
+- dist/batch_scoring  --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032 --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
+- dist/batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
 cache:
   directories:
   - "$HOME/.cache/pip"
@@ -53,19 +47,19 @@ before_cache:
 - rm -f $HOME/.cache/pip/log/debug.log
 after_success:
 - coveralls
-- if [[ $pyver = '3.5' ]]; then ./offline_install_scripts/travis_pyinstaller_osx.sh
-   $TRAVIS_COMMIT $TRAVIS_TAG ; fi 
+- if [[ $pyver = '3.5' ]]; then ./offline_install_scripts/travis_pyinstaller_osx.sh $TRAVIS_COMMIT $TRAVIS_TAG ; fi 
 deploy:
-  #  The builds pushed to "osx-tagged-build" should be release ready
+  #  The builds pushed to "osx-tagged-artifacts" should be release ready
   #  Should only upload builds triggered by a new tag and made with OSX/Python3.5.
   #  tarball will include the tag in name
   - provider: s3
-    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    access_key_id: AKIAJZGOHZRYJPG6MZXA
     secret_access_key:
-      secure: ***REMOVED***
+      secure: "Igus/RMcj7HMf3Xhyw06JvXctLHY/VW7yhY5flKCOJqQq5UjfWCa+Wc+rPIkzBGC4afiM/wZcnTBHgM2bkuvW1uOIwlgI4Bw20wAJV22HagTg7uQeKQv4bUWQYUy7PfLVnrxuZCUUxB774fF+wiYMIvQ1b6/uy25o9oJkCfmhE79xt5Bv2TrMEkGNTUCbA6/ix97bgQMoRy+jAS10Z6uDJzHjfrLfkCvA62WwpkkIZPWB3y91O6uzdoRKNPQ3YD2nlNz0PU7WVZq/J45wQji/xwA0Z9FsO0RgLHxWjOzDrHhxXfkBkvVuRcMj7k6L2PoK44z1TG7Z+wKVz4w5begLI5wV1OdbhBVgC2YHxNfFdLEidyMcbH3Eq1rb40Hyf1y3emzB3M97rfVKPO/uILZItVbvulwdsbzsnhgHORXXooKMwPz07fTLyOM0lFcGjukH/+DpJbj08gwOp3Iuh0wZmL2+1cvbqj3SUyDLvj9dyycglSCCFHIxT5h7nlKJCof3Q0TKn4iWC/wA26pnvJDm7Wp7H8VAroSoVm35t2t92mk0fzOLFBnhxD00VXGpkchhHFh4nLDJ3SxzQOV5+UxFIMQo1SVuvj7RRxufHVnvQoMzyH1A9m123oV/J+y0sqUIbtYtNvCVQX5L7ZmZIlBUMWhzHlBwkUstL2hnM8RwjA="
     local_dir: dist/OSX
-    bucket: batch-scoring-release-candidates
-    upload-dir: osx-tagged-build
+    bucket: datarobot-batch-scoring-artifacts
+    upload-dir: osx-tagged-artifacts
+    skip_cleanup: true
     on:
       repo: datarobot/batch-scoring
       tags: true
@@ -73,15 +67,17 @@ deploy:
   # This uploads builds made on PRs
   # The S3 bucket should delete builds after 60 days
   - provider: s3
-    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    access_key_id: AKIAJZGOHZRYJPG6MZXA
     secret_access_key:
-      secure: ***REMOVED***
+      secure: "Igus/RMcj7HMf3Xhyw06JvXctLHY/VW7yhY5flKCOJqQq5UjfWCa+Wc+rPIkzBGC4afiM/wZcnTBHgM2bkuvW1uOIwlgI4Bw20wAJV22HagTg7uQeKQv4bUWQYUy7PfLVnrxuZCUUxB774fF+wiYMIvQ1b6/uy25o9oJkCfmhE79xt5Bv2TrMEkGNTUCbA6/ix97bgQMoRy+jAS10Z6uDJzHjfrLfkCvA62WwpkkIZPWB3y91O6uzdoRKNPQ3YD2nlNz0PU7WVZq/J45wQji/xwA0Z9FsO0RgLHxWjOzDrHhxXfkBkvVuRcMj7k6L2PoK44z1TG7Z+wKVz4w5begLI5wV1OdbhBVgC2YHxNfFdLEidyMcbH3Eq1rb40Hyf1y3emzB3M97rfVKPO/uILZItVbvulwdsbzsnhgHORXXooKMwPz07fTLyOM0lFcGjukH/+DpJbj08gwOp3Iuh0wZmL2+1cvbqj3SUyDLvj9dyycglSCCFHIxT5h7nlKJCof3Q0TKn4iWC/wA26pnvJDm7Wp7H8VAroSoVm35t2t92mk0fzOLFBnhxD00VXGpkchhHFh4nLDJ3SxzQOV5+UxFIMQo1SVuvj7RRxufHVnvQoMzyH1A9m123oV/J+y0sqUIbtYtNvCVQX5L7ZmZIlBUMWhzHlBwkUstL2hnM8RwjA="
     local_dir: dist/OSX
-    bucket: batch-scoring-release-candidates
+    bucket: datarobot-batch-scoring-artifacts
     upload-dir: osx-dev-builds-not-for-release
+    skip_cleanup: true
     on:
       repo: datarobot/batch-scoring
       all_branches: true 
+      tags: false
       condition: $pyver = '3.5'
 
 ## Commented for testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,32 @@
 matrix:
   include:
-    - language: generic
-      python: 2.7
-      os: osx
-      env: pyver=2.7 pydist=macpython
-      sudo: required
-    - language: generic
-      python: 3.4
-      os: osx
-      env: pyver=3.4 pydist=macpython
-      sudo: required
-    - language: generic
-      python: 3.5
-      os: osx
-      env: pyver=3.5 pydist=macpython
-      sudo: required
-    - language: python
-      python: 2.7
-      os: linux
-    - language: python
-      python: 3.3
-      os: linux
-    - language: python
-      python: 3.4
-      os: linux
-    - language: python
-      python: 3.5
-      os: linux
+  - language: generic
+    python: 2.7
+    os: osx
+    env: pyver=2.7 pydist=macpython
+    sudo: required
+  - language: generic
+    python: 3.4
+    os: osx
+    env: pyver=3.4 pydist=macpython
+    sudo: required
+  - language: generic
+    python: 3.5
+    os: osx
+    env: pyver=3.5 pydist=macpython
+    sudo: required
+  - language: python
+    python: 2.7
+    os: linux
+  - language: python
+    python: 3.3
+    os: linux
+  - language: python
+    python: 3.4
+    os: linux
+  - language: python
+    python: 3.5
+    os: linux
 install:
 - if [ $TRAVIS_OS_NAME == 'osx' ]; then git clone https://github.com/MacPython/terryfy;
   source terryfy/travis_tools.sh; get_python_environment  $pydist $pyver; fi
@@ -53,17 +53,37 @@ before_cache:
 - rm -f $HOME/.cache/pip/log/debug.log
 after_success:
 - coveralls
-- if [[ $TRAVIS_TAG ]]; then if [[ $pyver = '3.5' ]]; then ./offline_install_scripts/travis_pyinstaller_osx.sh $TRAVIS_TAG ; fi ; fi
+- if [[ $pyver = '3.5' ]]; then ./offline_install_scripts/travis_pyinstaller_osx.sh
+   $TRAVIS_COMMIT $TRAVIS_TAG ; fi 
 deploy:
-  - provider: releases
-    api_key:
-      secure: bL1mFfmelX+8c7lA8d3FFK988bq8N1mDGPVgQtx835dC+hTxpxaKwg1PaAp8hHv8IB8FnSypW9nRaqrPZ8mDHCeKNprMTm4/uxcN15nKp2oSMrSGCObpStlkz2bCRAFaxP2j+GcDjnFS5CLlJ3u1fYRqyHwGVR+4stxPBLMOpunPtmSG6qFucqfXP0xkDlIqjRu9OZexD2EgBGWo+gbBp01bNxSf50RUu1uvRhnKn16prBfW11NKiSZEwDQfjqKLxxztRT0ZACHGuWnw9cmZwo4RMK8JEmDVhv6PziKRZeCsr1sDhPF4AXigNBLDmIlvdDXR8vYkOKyKqcdcNTMfdjKFgZq/a8sG5+e/jcvOZqkvOUkUnkfInygpju+5iSylUYhpkG3DRvdzfZ9YRq3/kS82ZulTStkxB9SNDipYn5gAuLX7WaEu6JJ5cdHsmRsXhBNFR7cOWOwFH/4MNn8jdCBp96R5iXmji1qGH3QVrwvZL/d/jQc+72IPf0A/1lMK8OTEX0qb4kUZ75mSZYKHJRVN8XQQUQ2KMnqEPy/pLNJCqR9w5+KnSYBJmjh+0B6Zv14fq/GlNPEzUlXOSNmgVuOarGs+QvPT8gQSilw7v9G/mQxHINgqyF9ZYxmbDpyHIez1YvlU9bCDw2q7IZzpUfUNN8Y0VTtjwzRaZQuRKR8=
-    file: dist/datarobot_batch_scoring_"$TRAVIS_TAG"_executables.OSX.x86_64.tar
-    skip_cleanup: true
+  #  The builds pushed to "osx-tagged-build" should be release ready
+  #  Should only upload builds triggered by a new tag and made with OSX/Python3.5.
+  #  tarball will include the tag in name
+  - provider: s3
+    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    secret_access_key:
+      secure: ***REMOVED***
+    local_dir: dist/OSX
+    bucket: batch-scoring-release-candidates
+    acl: ''
+    upload-dir: osx-tagged-build
     on:
       repo: datarobot/batch-scoring
       tags: true
-      all_branches: true
+      condition: $pyver = '3.5'
+  # This uploads builds made on PRs
+  # The S3 bucket should delete builds after 60 days
+  - provider: s3
+    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    secret_access_key:
+      secure: ***REMOVED***
+    local_dir: dist/OSX
+    bucket: batch-scoring-release-candidates
+    acl: ''
+    upload-dir: osx-dev-builds-not-for-release
+    on:
+      repo: datarobot/batch-scoring
+      all_branches: true 
       condition: $pyver = '3.5'
 
 ## Commented for testing

--- a/BATCH_SCORING_EXECUTABLE_README.txt
+++ b/BATCH_SCORING_EXECUTABLE_README.txt
@@ -2,10 +2,9 @@
 
 # Linux / OSX users
 
-# 1. Unzip or untar the executables 
+# 1. untar the executables 
 
-  unzip datarobot_batch_scoring_*_executables.Linux.x86_64.zip    # for zip
-  tar -xf datarobot_batch_scoring_*_executables.Linux.x86_64.tar  # for tar 
+  tar -xf datarobot_batch_scoring_*_executables.Linux.x86_64.tar  
 
 
 # 2. Install 
@@ -26,3 +25,10 @@
     batch_scoring --help                                   # test that it worked
 
 
+# Windows users
+
+# 1. unzip the executables 
+
+right-click > extract here
+
+# 2. move executables to user's path

--- a/BATCH_SCORING_EXECUTABLE_README.txt
+++ b/BATCH_SCORING_EXECUTABLE_README.txt
@@ -1,4 +1,4 @@
-# These directions are for installing the datarobot_batch_scoring executable 
+# To install we basically just need to get the executable onto the system PATH.
 
 # Linux / OSX users
 

--- a/BATCH_SCORING_EXECUTABLE_README.txt
+++ b/BATCH_SCORING_EXECUTABLE_README.txt
@@ -29,6 +29,31 @@
 
 # 1. unzip the executables 
 
-right-click > extract here
+  right-click > extract here
+  This will unzip a directory. Inside the directory are these directions and two .exe files. 
+
 
 # 2. move executables to user's path
+
+  make a directory, for example:
+    C:\Users\BILL\bin     # note that BILL would be replaced with your user name
+
+  copy the two .exe files to the new directory
+
+# 3. add the new directory to the user's path
+
+  - Click the the start menu
+  - In the search bar click the search bar and search for "path". 
+  - You are looking for a menue item called "Edit environment variables for your account"
+  - Open "Edit environment variables for your account"
+  - Select "PATH" and click edit.
+  - In the "Variable value" bar go to the end of the existing path and append a semicolon + your new dir location. 
+  - For example, this would be added at the end of BILL's path:
+
+      ;C:\Users\BILL\bin
+
+    don't delete anything else in the path and make sure you have a semicolon.
+
+  - Save and close
+  - Close any existing cmd shell and open a new cmd shell. 
+  - Try typing 'batch_scoring --help' in the command shell. The program should be found.

--- a/Makefile
+++ b/Makefile
@@ -27,23 +27,44 @@ pyinstaller: clean
 	#  On Linux use "make pyinstaller_dockerized"
 	./offline_install_scripts/build_pyinstaller.sh
 
-pyinstaller_dockerized: clean
-	docker run --rm -v ${CDIR}:/batch-scoring pyinstaller-centos5-py35-build \
-		/batch-scoring/offline_install_scripts/build_pyinstaller_dockerized.sh
+.install-docker-compose: clean
+	pip install -r requirements-docker-compose.txt -q
+
+pyinstaller_dockerized: .install-docker-compose
+	docker-compose run --rm centos5pyinstaller \
+	/batch-scoring/offline_install_scripts/build_pyinstaller_dockerized.sh 
 
 offlinebundle:
 	#  On Linux use "make offlinebundle_dockerized"
 	./offline_install_scripts/build_offlinebundle.sh
 
 offlinebundle_dockerized:
-	docker run --rm -v ${CDIR}:/batch-scoring python:3.5 \
+	docker run -i --rm -v ${CDIR}:/batch-scoring python:3.5 \
 		/batch-scoring/offline_install_scripts/build_offlinebundle_dockerized.sh
 
-build_release_dockerized: pyinstaller_dockerized offlinebundle_dockerized
+build_release_dockerized: clean pyinstaller_dockerized offlinebundle_dockerized
+
+
+test_offlinebundle_dockerized:
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring centos:7 /batch-scoring/offline_install_scripts/test_offlinebundle_dockerized.sh
+
+test_pyinstaller_dockerized:
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring centos:7 /batch-scoring/offline_install_scripts/test_pyinstaller_dockerized.sh
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring centos:5 /batch-scoring/offline_install_scripts/test_pyinstaller_dockerized.sh
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring centos:7 /batch-scoring/offline_install_scripts/test_pyinstaller_dockerized.sh
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring ubuntu:12.04 /batch-scoring/offline_install_scripts/test_pyinstaller_dockerized.sh
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring ubuntu:16.04 /batch-scoring/offline_install_scripts/test_pyinstaller_dockerized.sh
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring pritunl/archlinux:latest /batch-scoring/offline_install_scripts/test_pyinstaller_dockerized.sh
+	docker run -i --net=none --rm -v ${CDIR}:/batch-scoring gentoo/stage3-amd64 /batch-scoring/offline_install_scripts/test_pyinstaller_dockerized.sh 
+
+
+
 
 clean:
 	@rm -rf .install
 	@rm -rf .install-test-deps
+	@rm -rf .build_release_dockerized
+	@rm -rf .install-docker-compose
 	@rm -rf datarobot_batch_scoring.egg-info build/* dist/* 
 	@rm -rf htmlcov
 	@rm -rf .coverage

--- a/OFFLINEBUNDLE_INSTALL_README.txt
+++ b/OFFLINEBUNDLE_INSTALL_README.txt
@@ -6,15 +6,16 @@
 #    datarobot_batch_scoring_1.10.0_offlinebundle.zip
 # you must have python 2.7 or python 3 installed, but pip is NOT required
 
-# unzip the offlinebundle zip file and change directory into offlinebundle
+# unzip the batch_scoring_offlinebundle zip file and change directory into batch_scoring_offlinebundle
 # E.g. 
 
 unzip datarobot_batch_scoring_1.10.0_offlinebundle.zip
-cd datarobot_batch_scoring_1.10.0_offlinebundle
+cd batch_scoring_offlinebundle
 
-### Section 2 - bootstrap pip
+### Section 2 - bootstrap pip 
 
-# If you have pip, you can skip this section.
+# If you have pip, you can skip this section and go to Section 3
+# you might also need to go throught these steps if pip is outdated
 
 # run the following command to install pip in --user mode
 # note you can use "python3" instead of "python" if that is an option
@@ -29,7 +30,7 @@ python -m pip install --user --no-index --find-links=helper_packages/ helper_pac
 # On Linux this can be done by appending a line to your user's ~/.bashrc
 # 
 
-echo 'export PATH=$PATH:~/bin' >> ~/.bashrc 
+echo 'export PATH=~/.local/bin:$PATH' >> ~/.bashrc 
 
 # then source the file if on Linux
 source ~/.bashrc
@@ -38,14 +39,18 @@ source ~/.bashrc
 pip --version
 > pip 9.0.1 from /home/user/.local/lib/python2.7/site-packages (python 2.7)
 
+### Section 3 - install datarobot_batch_scoring
+
 # at this point we could create and use a virtualenv if we wanted to. If you 
 # know what you are doing and want to use a virtualenv, go right ahead. 
-# That being said, it might be easier for the user if they don't need to know 
-# about virtualenvs so in the case we are installing it in --user mode. 
 
-pip install --user --no-index --find-links=required_packages/ required_packages/* 
+# If using virtualenv:
+    pip install --no-index --find-links=required_packages/ required_packages/* 
+# Otherwise:
+    pip install --user --no-index --find-links=required_packages/ required_packages/* 
 
-# test it out 
 
-batch_scoring --version
+### Section 4 - install datarobot_batch_scoring
+
+batch_scoring --help
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ We publish two alternative install methods on our releases_ page. These are for 
 
 :PyInstaller:
     Using pyinstaller_ we build a single-file-executable that does not depend on Python. It only depends on libc and can be installed without administrative privileges.
-    Right now we publish builds that work for most Linux distros. Other NIX platforms (like OSX), and Windows are in the works.
+    Right now we publish builds that work for most Linux distros made since Centos5. OSX and Windows are also supported.
     
     These files have "executables" in their name on the release page.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,8 @@ after_test:
   - "build.cmd 7z a build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
 
 artifacts:
-  - path: dist\*
+  - path: 'build\PR\*.zip'
+  - path: 'build\TAG\*.zip'
 
 deploy:
   # This only pushes when a tag is pushed. This is the release build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,9 @@
+version: $(APPVEYOR_BUILD_NUMBER)
 platform: x64
 matrix:
   fast_finish: true
 
 environment:
-  BUILD_ID: $(APPVEYOR_BUILD_NUMBER)-$(APPVEYOR_REPO_BRANCH)
-  RELEASE_ZIP: datarobot_batch_scoring_$(APPVEYOR_REPO_TAG_NAME)_executables.Windows.x86_64.zip
   PYPI_PASSWD:
     secure: u+K6dKi7+CXXVFEUG4V7zUyV3w7Ntg0Ork/RGVV0eSQ=
   matrix:
@@ -34,53 +33,47 @@ test_script:
 
 after_test:
   - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
-  - "build.cmd 7z a dist\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip dist\\batch_scoring.exe dist\\batch_scoring_sse.exe"
-  - "build.cmd ECHO %RELEASE_ZIP%"  
-  - ps: >-
-      if($env:appveyor_repo_tag -eq 'true') {
-          if($env:PYTHON -eq 'C:\\Python35-x64') {
-              cd dist
-              7z a $env:RELEASE_ZIP batch_scoring.exe batch_scoring_sse.exe ../BATCH_SCORING_EXECUTABLE_README.txt
-              del batch_scoring.exe batch_scoring_sse.exe
-          }
-      }
-  # - "build.cmd del dist\\batch_scoring.exe dist\\batch_scoring_sse.exe"
+  - "build.cmd mkdir build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "build.cmd mkdir build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "build.cmd COPY dist\\batch_scoring.exe +dist\\batch_scoring_sse.exe +BATCH_SCORING_EXECUTABLE_README.txt build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "build.cmd COPY dist\\batch_scoring.exe +dist\\batch_scoring_sse.exe +BATCH_SCORING_EXECUTABLE_README.txt build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "build.cmd 7z a build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64.zip build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "build.cmd 7z a build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
 
 artifacts:
   - path: dist\*
+
+deploy:
+  # This only pushes when a tag is pushed. This is the release build
+  - provider: S3
+    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    secret_access_key:
+      secure: JunkjvwVSicgKSfNZzSWTqMyc5qLV4tkLNv0M/MQDM8f9B+2kwNt+F3Usj4EAZL9
+    bucket: batch-scoring-release-candidates
+    region: us-east-1
+    set_public: false
+    folder: windows-tagged-build/
+    artifact: build\\TAG\\*.zip
+    on:
+      appveyor_repo_tag: true
+      PYTHON: "C:\\Python35-x64"
+  # This pushes a windows build on each PR
+  - provider: S3
+    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    secret_access_key:
+      secure: JunkjvwVSicgKSfNZzSWTqMyc5qLV4tkLNv0M/MQDM8f9B+2kwNt+F3Usj4EAZL9
+    bucket: batch-scoring-release-candidates
+    region: us-east-1
+    set_public: false
+    folder: windows-dev-builds-not-for-release/$(APPVEYOR_BUILD_NUMBER)
+    artifact: build\\PR\\*.zip
+    on:
+      appveyor_repo_tag: false
+      PYTHON: "C:\\Python35-x64"
+
 
 #notifications:
 #  - provider: Webhook
 #    url: https://ci.appveyor.com/api/github/webhook?id=08c7793w1tp839fl
 #    on_build_success: false
 #    on_build_failure: True
-
-#   # release: myproduct-v$(appveyor_build_version)
-# deploy:
-#   - provider: GitHub
-#     description: 'Windows batch_scoring single-file-executables'
-#     auth_token:
-#       secure: x3h6EkNA6bT0pc9W66lV728BIooYtNBU7ApRmpWO0mC1ddbNKUlHzB8dybH76M3Q
-#     artifact: "dist\\datarobot_batch_scoring_executables.Windows.x86_64.zip"
-#     release: $(APPVEYOR_REPO_TAG_NAME)
-#     draft: false
-#     prerelease: false
-#     force_update: true
-#     on:
-#       appveyor_repo_tag: true        # deploy on tag push only
-#       platform: x64
-#       # branch: master                 # release from master branch only
-# deploy:
-#   # Development branch, deploy to github
-#   - provider: GitHub
-#     auth_token:
-#     secure: x3h6EkNA6bT0pc9W66lV728BIooYtNBU7ApRmpWO0mC1ddbNKUlHzB8dybH76M3Q
-#     release: $(BUILD_ID)-windows-dev
-#     # description needs to be declared, but can be empty, so that github not reject the deploy
-#     description: "This is a development release. It should not be used in production environments."
-#     artifact: "dist\\datarobot_batch_scoring_executables.Windows.x86_64.zip"
-#     draft: false
-#     prerelease: false
-#     on:
-#       appveyor_repo_tag: false
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,3 +81,4 @@ deploy:
     on:
       appveyor_repo_tag: false
       PYTHON: "C:\\Python35-x64"
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,17 @@
-version: 1.8.0a0.dev{build}
+platform: x64
+matrix:
+  fast_finish: true
 
 environment:
+  BUILD_ID: $(APPVEYOR_BUILD_NUMBER)-$(APPVEYOR_REPO_BRANCH)
+  RELEASE_ZIP: datarobot_batch_scoring_$(APPVEYOR_REPO_TAG_NAME)_executables.Windows.x86_64.zip
   PYPI_PASSWD:
     secure: u+K6dKi7+CXXVFEUG4V7zUyV3w7Ntg0Ork/RGVV0eSQ=
   matrix:
-    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python27-x64"
+    # - PYTHON: "C:\\Python35"
+    # - PYTHON: "C:\\Python27"
+    # - PYTHON: "C:\\Python27-x64"
 
 install:
   - "build.cmd %PYTHON%\\python.exe -m pip install -U pip"
@@ -16,25 +20,67 @@ install:
   - "build.cmd %PYTHON%\\python.exe -m pip install -r requirements-test.txt"
   - "build.cmd %PYTHON%\\python.exe -m pip install -e ."
 
+
 build: false
 
 test_script:
   - "build.cmd %PYTHON%\\python.exe -m pytest -vvv"
+  - "build.cmd %PYTHON%\\python.exe -m pip install -r requirements-pyinstaller.txt -U urllib3[secure]"
+  - "build.cmd %PYTHON%\\python.exe -m pip uninstall -y datarobot_batch_scoring"
+  - "build.cmd %PYTHON%\\Scripts\\pyinstaller.exe -y --distpath=dist/ --onefile -n batch_scoring batch_scoring.py"
+  - "build.cmd %PYTHON%\\Scripts\\pyinstaller.exe -y --distpath=dist/ --onefile -n batch_scoring_sse batch_scoring_sse.py"
+  - "dist\\batch_scoring.exe --host=https://foo.bar.com --user=fooy@example.com --api_token=00000000000000000000000000000032 --datarobot_key=000000000000000000000000000000000036 000000000000000000000024 000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y"
+  - "dist\\batch_scoring_sse.exe --host=https://foo.bar.com  000000000000000000000024 tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y"
 
 after_test:
   - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
+  - "build.cmd 7z a dist\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip dist\\batch_scoring.exe dist\\batch_scoring_sse.exe"
+  - "build.cmd ECHO %RELEASE_ZIP%"  
+  - ps: >-
+      if($env:appveyor_repo_tag -eq 'true') {
+          if($env:PYTHON -eq 'C:\\Python35-x64') {
+              cd dist
+              7z a $env:RELEASE_ZIP batch_scoring.exe batch_scoring_sse.exe ../BATCH_SCORING_EXECUTABLE_README.txt
+              del batch_scoring.exe batch_scoring_sse.exe
+          }
+      }
+  # - "build.cmd del dist\\batch_scoring.exe dist\\batch_scoring_sse.exe"
 
 artifacts:
   - path: dist\*
-
-#deploy_script:
-#  - ps: >-
-#      if($env:appveyor_repo_tag -eq 'True') {
-#          Invoke-Expression "$env:PYTHON\\python.exe -m twine upload dist/* --username# andrew.svetlov --password $env:PYPI_PASSWD"
-#      }
 
 #notifications:
 #  - provider: Webhook
 #    url: https://ci.appveyor.com/api/github/webhook?id=08c7793w1tp839fl
 #    on_build_success: false
 #    on_build_failure: True
+
+#   # release: myproduct-v$(appveyor_build_version)
+# deploy:
+#   - provider: GitHub
+#     description: 'Windows batch_scoring single-file-executables'
+#     auth_token:
+#       secure: x3h6EkNA6bT0pc9W66lV728BIooYtNBU7ApRmpWO0mC1ddbNKUlHzB8dybH76M3Q
+#     artifact: "dist\\datarobot_batch_scoring_executables.Windows.x86_64.zip"
+#     release: $(APPVEYOR_REPO_TAG_NAME)
+#     draft: false
+#     prerelease: false
+#     force_update: true
+#     on:
+#       appveyor_repo_tag: true        # deploy on tag push only
+#       platform: x64
+#       # branch: master                 # release from master branch only
+# deploy:
+#   # Development branch, deploy to github
+#   - provider: GitHub
+#     auth_token:
+#     secure: x3h6EkNA6bT0pc9W66lV728BIooYtNBU7ApRmpWO0mC1ddbNKUlHzB8dybH76M3Q
+#     release: $(BUILD_ID)-windows-dev
+#     # description needs to be declared, but can be empty, so that github not reject the deploy
+#     description: "This is a development release. It should not be used in production environments."
+#     artifact: "dist\\datarobot_batch_scoring_executables.Windows.x86_64.zip"
+#     draft: false
+#     prerelease: false
+#     on:
+#       appveyor_repo_tag: false
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ deploy:
     bucket: batch-scoring-release-candidates
     region: us-east-1
     set_public: false
-    folder: windows-tagged-build/
+    folder: windows-tagged-build
     artifact: build\\TAG\\*.zip
     on:
       appveyor_repo_tag: true
@@ -65,7 +65,7 @@ deploy:
     bucket: batch-scoring-release-candidates
     region: us-east-1
     set_public: false
-    folder: windows-dev-builds-not-for-release/$(APPVEYOR_BUILD_NUMBER)
+    folder: windows-dev-builds-not-for-release
     artifact: build\\PR\\*.zip
     on:
       appveyor_repo_tag: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: $(APPVEYOR_BUILD_NUMBER)
+version: '{build}'
 platform: x64
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,14 +8,13 @@ environment:
     secure: u+K6dKi7+CXXVFEUG4V7zUyV3w7Ntg0Ork/RGVV0eSQ=
   matrix:
     - PYTHON: "C:\\Python35-x64"
-    # - PYTHON: "C:\\Python35"
-    # - PYTHON: "C:\\Python27"
-    # - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
 
 install:
   - "build.cmd %PYTHON%\\python.exe -m pip install -U pip"
   - "build.cmd %PYTHON%\\python.exe -m pip install wheel"
-#  - "build.cmd %PYTHON%\\python.exe -m pip install twine"
   - "build.cmd %PYTHON%\\python.exe -m pip install -r requirements-test.txt"
   - "build.cmd %PYTHON%\\python.exe -m pip install -e ."
 
@@ -33,57 +32,52 @@ test_script:
 
 after_test:
   - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
-  - "build.cmd mkdir build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
-  - "build.cmd mkdir build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "mkdir build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "mkdir build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
 
-  - "build.cmd COPY dist\\batch_scoring.exe build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
-  - "build.cmd COPY dist\\batch_scoring_sse.exe build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
-  - "build.cmd COPY BATCH_SCORING_EXECUTABLE_README.txt build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "COPY dist\\batch_scoring.exe build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "COPY dist\\batch_scoring_sse.exe build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "COPY BATCH_SCORING_EXECUTABLE_README.txt build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
 
-  - "build.cmd COPY dist\\batch_scoring.exe build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
-  - "build.cmd COPY dist\\batch_scoring_sse.exe build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
-  - "build.cmd COPY BATCH_SCORING_EXECUTABLE_README.txt build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
-  - "build.cmd cd build\\PR"
-  - "build.cmd 7z a datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64.zip datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
-  - "build.cmd ..\\.."
-  - "build.cmd cd build\\TAG"
-  - "build.cmd 7z a datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "COPY dist\\batch_scoring.exe build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "COPY dist\\batch_scoring_sse.exe build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "COPY BATCH_SCORING_EXECUTABLE_README.txt build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - ps: cd build\\PR
+  - "7z a datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64.zip datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "COPY datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64.zip ..\\..\\"
+  - ps: cd ..\\..
+  - ps: cd build\\TAG
+  - "7z a datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "COPY datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip ..\\..\\"
 
 artifacts:
-  - path: 'build\PR\*.zip'
-  - path: 'build\TAG\*.zip'
+  - path: "datarobot_batch_scoring_$(APPVEYOR_REPO_TAG_NAME)_executables.Windows.x86_64.zip"
+  - path: "datarobot_batch_scoring_$(APPVEYOR_REPO_COMMIT)_executables.Windows.x86_64.zip"
 
 deploy:
   # This only pushes when a tag is pushed. This is the release build
   - provider: S3
-    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    access_key_id: AKIAJZGOHZRYJPG6MZXA
     secret_access_key:
-      secure: JunkjvwVSicgKSfNZzSWTqMyc5qLV4tkLNv0M/MQDM8f9B+2kwNt+F3Usj4EAZL9
-    bucket: batch-scoring-release-candidates
+      secure: 4hoRmOYhISdTVcwqEhaQDQWsZKrYZYE3QBpjZHyvAkDyT0rcphoxJaXU/LXIuRxe
+    bucket: datarobot-batch-scoring-artifacts
     region: us-east-1
     set_public: false
-    folder: windows-tagged-build
-    artifact: build\\TAG\\*.zip
+    folder: windows-tagged-artifacts
+    artifact: "datarobot_batch_scoring_$(APPVEYOR_REPO_TAG_NAME)_executables.Windows.x86_64.zip"
     on:
       appveyor_repo_tag: true
       PYTHON: "C:\\Python35-x64"
   # This pushes a windows build on each PR
   - provider: S3
-    access_key_id: AKIAJ2W2S2GOXXIHGF6Q
+    access_key_id: AKIAJZGOHZRYJPG6MZXA
     secret_access_key:
-      secure: JunkjvwVSicgKSfNZzSWTqMyc5qLV4tkLNv0M/MQDM8f9B+2kwNt+F3Usj4EAZL9
-    bucket: batch-scoring-release-candidates
+      secure: 4hoRmOYhISdTVcwqEhaQDQWsZKrYZYE3QBpjZHyvAkDyT0rcphoxJaXU/LXIuRxe
+    bucket: datarobot-batch-scoring-artifacts
     region: us-east-1
     set_public: false
     folder: windows-dev-builds-not-for-release
-    artifact: build\\PR\\*.zip
+    artifact: "datarobot_batch_scoring_$(APPVEYOR_REPO_COMMIT)_executables.Windows.x86_64.zip"
     on:
       appveyor_repo_tag: false
       PYTHON: "C:\\Python35-x64"
-
-
-#notifications:
-#  - provider: Webhook
-#    url: https://ci.appveyor.com/api/github/webhook?id=08c7793w1tp839fl
-#    on_build_success: false
-#    on_build_failure: True

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,19 @@ after_test:
   - "build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"
   - "build.cmd mkdir build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
   - "build.cmd mkdir build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
-  - "build.cmd COPY dist\\batch_scoring.exe +dist\\batch_scoring_sse.exe +BATCH_SCORING_EXECUTABLE_README.txt build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
-  - "build.cmd COPY dist\\batch_scoring.exe +dist\\batch_scoring_sse.exe +BATCH_SCORING_EXECUTABLE_README.txt build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
-  - "build.cmd 7z a build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64.zip build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
-  - "build.cmd 7z a build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+
+  - "build.cmd COPY dist\\batch_scoring.exe build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "build.cmd COPY dist\\batch_scoring_sse.exe build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "build.cmd COPY BATCH_SCORING_EXECUTABLE_README.txt build\\PR\\datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+
+  - "build.cmd COPY dist\\batch_scoring.exe build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "build.cmd COPY dist\\batch_scoring_sse.exe build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "build.cmd COPY BATCH_SCORING_EXECUTABLE_README.txt build\\TAG\\datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
+  - "build.cmd cd build\\PR"
+  - "build.cmd 7z a datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64.zip datarobot_batch_scoring_%APPVEYOR_REPO_COMMIT%_executables.Windows.x86_64"
+  - "build.cmd ..\\.."
+  - "build.cmd cd build\\TAG"
+  - "build.cmd 7z a datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64.zip datarobot_batch_scoring_%APPVEYOR_REPO_TAG_NAME%_executables.Windows.x86_64"
 
 artifacts:
   - path: 'build\PR\*.zip'

--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import warnings
+from multiprocessing import freeze_support
 
 from datarobot_batch_scoring import __version__
 from datarobot_batch_scoring.batch_scoring import (run_batch_predictions)
@@ -315,6 +316,7 @@ def parse_generic_options(parsed_args):
 
 
 def main(argv=sys.argv[1:]):
+    freeze_support()
     global ui  # global variable hack, will get rid of a bit later
     warnings.simplefilter('ignore')
     parsed_args = parse_args(argv)
@@ -370,6 +372,7 @@ def main(argv=sys.argv[1:]):
 
 
 def main_standalone(argv=sys.argv[1:]):
+    freeze_support()
     global ui  # global variable hack, will get rid of a bit later
     warnings.simplefilter('ignore')
     parsed_args = parse_args(argv, standalone=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,3 +49,5 @@ services:
      build:
         context: .
         dockerfile: Dockerfile-pyinstaller-centos5-py35-build
+     volumes:
+        - .:/batch-scoring

--- a/offline_install_scripts/build_offlinebundle.sh
+++ b/offline_install_scripts/build_offlinebundle.sh
@@ -9,26 +9,26 @@ cd $REPO_BASE
 # venv as a module requires python3.4+
 PYTHON=`which python3.5 || which python3`
 
-rm -rf /tmp/TEMPVENV ./dist/offlinebundle
+rm -rf /tmp/TEMPVENV ./dist/batch_scoring_offlinebundle
 $PYTHON -m venv /tmp/TEMPVENV
 . /tmp/TEMPVENV/bin/activate
 
-mkdir -p dist/offlinebundle/required_packages dist/offlinebundle/helper_packages
-cp OFFLINEBUNDLE_INSTALL_README.txt dist/offlinebundle/
+mkdir -p dist/batch_scoring_offlinebundle/required_packages dist/batch_scoring_offlinebundle/helper_packages
+cp OFFLINEBUNDLE_INSTALL_README.txt dist/batch_scoring_offlinebundle/
 wget https://bootstrap.pypa.io/get-pip.py
 #  add documentation to zip
-mv get-pip.py dist/offlinebundle/
+mv get-pip.py dist/batch_scoring_offlinebundle/
 
 pip install -U pip setuptools
 python setup.py sdist
 VERSION=$($PYTHON -c 'from datarobot_batch_scoring.__init__ import __version__ as v ; print(v)')
-pip download --dest=dist/offlinebundle/helper_packages --no-cache-dir --only-binary :all: \
+pip download --dest=dist/batch_scoring_offlinebundle/helper_packages --no-cache-dir --only-binary :all: \
 				--implementation=py --abi=none --platform=any \
 				pip setuptools virtualenv wheel appdirs \
 				pyparsing six packaging
-pip download --dest=dist/offlinebundle/required_packages --no-cache-dir --no-binary :all: \
+pip download --dest=dist/batch_scoring_offlinebundle/required_packages --no-cache-dir --no-binary :all: \
 				dist/datarobot_batch_scoring-"${VERSION}".tar.gz
 rm dist/datarobot_batch_scoring-"${VERSION}".tar.gz
 cd ./dist
-zip -r -0 datarobot_batch_scoring_"${VERSION}"_offlinebundle.zip offlinebundle
-tar -cf datarobot_batch_scoring_"${VERSION}"_offlinebundle.tar offlinebundle
+zip -r -0 datarobot_batch_scoring_"${VERSION}"_offlinebundle.zip batch_scoring_offlinebundle
+tar -cf datarobot_batch_scoring_"${VERSION}"_offlinebundle.tar batch_scoring_offlinebundle

--- a/offline_install_scripts/test_offlinebundle.sh
+++ b/offline_install_scripts/test_offlinebundle.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#  On Linux this should be run inside Docker and triggered by ./build_pyinstaller_dockerized.sh
+#  On OSX or other *nixes it would be run without docker
+set -e
+REPO_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+cd $REPO_BASE
+VERSION=$(grep -o -E '[^'\'']+' datarobot_batch_scoring/__init__.py | grep -v "version")
+: "${VERSION:?Need to set VERSION non-empty}"
+BUNDLE=datarobot_batch_scoring_"${VERSION}"_offlinebundle
+
+rm -rf /tmp/test_offlinebundle 
+mkdir -p /tmp/test_offlinebundle/
+cp dist/"${BUNDLE}".tar /tmp/test_offlinebundle/
+
+cd /tmp/test_offlinebundle/
+tar -xf "${BUNDLE}".tar
+cd batch_scoring_offlinebundle
+which python || whereis python
+python --version
+python get-pip.py --user --no-index --find-links=helper_packages/
+export PATH=~/.local:$PATH
+python -m pip install --user --no-index --find-links=helper_packages/ helper_packages/*
+# Now the user will always be able to use the commands:
+pip install --user --no-index --find-links=required_packages/ required_packages/* 
+cd ~/
+pip --help > /dev/null
+virtualenv --help > /dev/null
+batch_scoring --help > /dev/null
+batch_scoring_sse --help > /dev/null
+
+batch_scoring  --host=https://foo.bar.com --user=fooy@example.com \
+	--api_token=00000000000000000000000000000032 \
+	--datarobot_key=000000000000000000000000000000000036 \
+	000000000000000000000024 000000000000000000000024 \
+	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz \
+	--dry_run --compress  -y
+
+batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 \
+	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y

--- a/offline_install_scripts/test_offlinebundle.sh
+++ b/offline_install_scripts/test_offlinebundle.sh
@@ -32,8 +32,8 @@ batch_scoring  --host=https://foo.bar.com --user=fooy@example.com \
 	--api_token=00000000000000000000000000000032 \
 	--datarobot_key=000000000000000000000000000000000036 \
 	000000000000000000000024 000000000000000000000024 \
-	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz \
+	"${REPO_BASE}"/tests/fixtures/criteo_top30_1m.csv.gz \
 	--dry_run --compress  -y
 
 batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 \
-	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
+	"${REPO_BASE}"/tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y

--- a/offline_install_scripts/test_offlinebundle_dockerized.sh
+++ b/offline_install_scripts/test_offlinebundle_dockerized.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Usage: invoked my "make pyinstaller_dockerized"
+# it is meant to run inside a docker container where it sets up the environment
+# it then calls the "make pyinstaller" build command
+
+HUID=`ls -nd /batch-scoring | cut --delimiter=' ' -f 3`
+useradd -m -s /bin/bash -u $HUID user 
+# #  use python3.5 for the pyinstaller build
+su user -c -l "/batch-scoring/offline_install_scripts/test_offlinebundle.sh"
+

--- a/offline_install_scripts/test_pyinstaller.sh
+++ b/offline_install_scripts/test_pyinstaller.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#  On Linux this should be run inside Docker and triggered by ./test_pyinstaller_dockerized.sh
+#  On OSX or other *nixes it would be run without docker
+# 
+set -e
+
+REPO_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+cd $REPO_BASE
+VERSION=$(grep -o -E '[^'\'']+' datarobot_batch_scoring/__init__.py | grep -v "version")
+: "${VERSION:?Need to set VERSION non-empty}"
+EXECUTABLE=datarobot_batch_scoring_"${VERSION}"_executables
+
+rm -rf /tmp/test_pyinstaller 
+mkdir -p /tmp/test_pyinstaller
+cp dist/"${EXECUTABLE}"*.tar /tmp/test_pyinstaller
+
+cd /tmp/test_pyinstaller/
+tar -xf "${EXECUTABLE}"*.tar
+cd "${EXECUTABLE}"*/
+mkdir -p ~/bin
+cp batch_scoring batch_scoring_sse ~/bin
+export PATH=$PATH:~/bin
+cd /tmp/
+
+# dry-run test that the executables can start
+batch_scoring --help > /dev/null
+batch_scoring_sse --help > /dev/null
+batch_scoring  --host=https://foo.bar.com --user=fooy@example.com \
+	--api_token=00000000000000000000000000000032 \
+	--datarobot_key=000000000000000000000000000000000036 \
+	000000000000000000000024 000000000000000000000024 \
+	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz \
+	--dry_run --compress  -y
+
+batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 \
+	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
+

--- a/offline_install_scripts/test_pyinstaller.sh
+++ b/offline_install_scripts/test_pyinstaller.sh
@@ -29,9 +29,9 @@ batch_scoring  --host=https://foo.bar.com --user=fooy@example.com \
 	--api_token=00000000000000000000000000000032 \
 	--datarobot_key=000000000000000000000000000000000036 \
 	000000000000000000000024 000000000000000000000024 \
-	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz \
+	"${REPO_BASE}"/tests/fixtures/criteo_top30_1m.csv.gz \
 	--dry_run --compress  -y
 
 batch_scoring_sse  --host=https://foo.bar.com  000000000000000000000024 \
-	/batch-scoring/tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
+	"${REPO_BASE}"/tests/fixtures/criteo_top30_1m.csv.gz --dry_run --compress  -y
 

--- a/offline_install_scripts/test_pyinstaller_dockerized.sh
+++ b/offline_install_scripts/test_pyinstaller_dockerized.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Usage: invoked my "make pyinstaller_dockerized"
+# it is meant to run inside a docker container where it sets up the environment
+# it then calls the "make pyinstaller" build command
+
+HUID=`ls -nd /batch-scoring | cut --delimiter=' ' -f 3`
+useradd -m -s /bin/bash -u $HUID user 
+su user -c -l "/batch-scoring/offline_install_scripts/test_pyinstaller.sh"
+

--- a/offline_install_scripts/travis_pyinstaller_osx.sh
+++ b/offline_install_scripts/travis_pyinstaller_osx.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+set -x
+# bundles up the OSX PyInstaller build
+TRAVIS_TAG=$1
+REPO_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+cd $REPO_BASE
+mkdir -p dist/datarobot_batch_scoring_executables
+#  add documentation to zip
+cp BATCH_SCORING_EXECUTABLE_README.txt dist/datarobot_batch_scoring_executables/
+cd dist
+cp batch_scoring batch_scoring_sse datarobot_batch_scoring_executables/
+tar -cf datarobot_batch_scoring_"${TRAVIS_TAG}"_executables.OSX.x86_64.tar datarobot_batch_scoring_executables

--- a/offline_install_scripts/travis_pyinstaller_osx.sh
+++ b/offline_install_scripts/travis_pyinstaller_osx.sh
@@ -2,7 +2,14 @@
 set -e
 set -x
 # bundles up the OSX PyInstaller build
-TRAVIS_TAG=$1
+TRAVIS_COMMIT=$1
+TRAVIS_TAG=$2
+if [[ $TRAVIS_TAG ]]
+then 
+    VERS=$TRAVIS_TAG
+else
+    VERS=$TRAVIS_COMMIT
+fi
 REPO_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 cd $REPO_BASE
 mkdir -p dist/datarobot_batch_scoring_executables
@@ -10,4 +17,7 @@ mkdir -p dist/datarobot_batch_scoring_executables
 cp BATCH_SCORING_EXECUTABLE_README.txt dist/datarobot_batch_scoring_executables/
 cd dist
 cp batch_scoring batch_scoring_sse datarobot_batch_scoring_executables/
-tar -cf datarobot_batch_scoring_"${TRAVIS_TAG}"_executables.OSX.x86_64.tar datarobot_batch_scoring_executables
+tar -cf datarobot_batch_scoring_"${VERS}"_executables.OSX.x86_64.tar datarobot_batch_scoring_executables
+mkdir OSX
+mv datarobot_batch_scoring_"${VERS}"_executables.OSX.x86_64.tar OSX/
+

--- a/requirements-docker-compose.txt
+++ b/requirements-docker-compose.txt
@@ -1,0 +1,1 @@
+docker-compose==1.11.1


### PR DESCRIPTION
This works by making builds for windows in Appveyor python3.5_x64 and OSX builds in Travis using Py3.5.
Every PR build will go to a folder in S3 where it will be saved for 60 days.
Every time a tag is pushed, builds will be sent to a different folder in an S3 bucket where they can be collected and attached to the release.
Linux builds will still be made locally inside our special docker container, but that could also be automated with travis. It just doesn't seem necessary at this time.
We made special AWS credentials that just allow pushing to this one S3 bucket. 

The DEV DOCS explain the process in more detail.

