### PR TITLE
Support wide fields [PRED-965]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.11.0 (beta)
+=============
+* New parameter `field_size_limit` allows users to specify a larger maximum field
+  size than the Python `csv` module normally allows. Users can use a larger number
+  for this value if they encounter issues with very large text fields, for example.
+  Please note that using larger values for this parameter may cause issues with
+  memory consumption.
+
 1.10.2 (2017 May 9)
 ================
 * Set default timeout on server response to infinity.

--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+import csv
 import multiprocessing
 import os
 import platform
@@ -62,7 +63,10 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
                           dry_run, encoding, skip_dialect,
                           skip_row_id=False,
                           output_delimiter=None,
-                          max_batch_size=None, compression=None):
+                          max_batch_size=None, compression=None,
+                          field_size_limit=None):
+
+    csv.field_size_limit(field_size_limit)
 
     if max_batch_size is None:
         max_batch_size = MAX_BATCH_SIZE

--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -66,7 +66,8 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
                           max_batch_size=None, compression=None,
                           field_size_limit=None):
 
-    csv.field_size_limit(field_size_limit)
+    if field_size_limit is not None:
+        csv.field_size_limit(field_size_limit)
 
     if max_batch_size is None:
         max_batch_size = MAX_BATCH_SIZE

--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -187,10 +187,10 @@ def parse_args(argv, standalone=False):
                              '"|"')
     csv_gr.add_argument('--field_size_limit', type=str, default=None,
                         help='Override the maximum field size. May be '
-                             'necessary for datasets with very wide text fields, '
-                             'but can lead to memory issues. Use `max` for the '
-                             'system maximum value, otherwise specify an integer '
-                             'for the number of bytes.')
+                             'necessary for datasets with very wide text '
+                             'fields, but can lead to memory issues. Use '
+                             '`max` for the system maximum value, otherwise specify '
+                             'an integer for the number of bytes.')
     misc_gr = parser.add_argument_group('Miscellaneous')
     misc_gr.add_argument('-y', '--yes', dest='prompt', action='store_true',
                          help="Always answer 'yes' for user prompts")
@@ -233,9 +233,10 @@ def parse_args(argv, standalone=False):
 
 
 def _parse_field_size_limit(fsl):
-    """Users can either (1) not specify (i.e. will be `None`) in which case we will use
-    the system default, (2) use the string `max` in which case we will use sys.maxsize,
-    or (3) specify an integer for how many bytes a field can take up
+    """Users can either (1) not specify (i.e. will be `None`) in which case 
+    we will use the system default, (2) use the string `max` in which case we
+    will use sys.maxsize, or (3) specify an integer for how many bytes a 
+    field can take up
     """
     if fsl is None:
         return fsl

--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -237,8 +237,10 @@ def _parse_field_size_limit(fsl):
     the system default, (2) use the string `max` in which case we will use sys.maxsize,
     or (3) specify an integer for how many bytes a field can take up
     """
-    if fsl is None or fsl == 'max':
+    if fsl is None:
         return fsl
+    if fsl == 'max':
+        return sys.maxsize
     try:
         return int(fsl)
     except ValueError:

--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -189,8 +189,8 @@ def parse_args(argv, standalone=False):
                         help='Override the maximum field size. May be '
                              'necessary for datasets with very wide text '
                              'fields, but can lead to memory issues. Use '
-                             '`max` for the system maximum value, otherwise specify '
-                             'an integer for the number of bytes.')
+                             '`max` for the system maximum value, otherwise '
+                             'specify an integer for the number of bytes.')
     misc_gr = parser.add_argument_group('Miscellaneous')
     misc_gr.add_argument('-y', '--yes', dest='prompt', action='store_true',
                          help="Always answer 'yes' for user prompts")
@@ -233,9 +233,9 @@ def parse_args(argv, standalone=False):
 
 
 def _parse_field_size_limit(fsl):
-    """Users can either (1) not specify (i.e. will be `None`) in which case 
+    """Users can either (1) not specify (i.e. will be `None`) in which case
     we will use the system default, (2) use the string `max` in which case we
-    will use sys.maxsize, or (3) specify an integer for how many bytes a 
+    will use sys.maxsize, or (3) specify an integer for how many bytes a
     field can take up
     """
     if fsl is None:

--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -185,12 +185,10 @@ def parse_args(argv, standalone=False):
                              'keyword "tab" can be used to indicate a tab '
                              'delimited csv. "pipe" can be used to indicate '
                              '"|"')
-    csv_gr.add_argument('--field_size_limit', type=str, default=None,
+    csv_gr.add_argument('--field_size_limit', type=int, default=None,
                         help='Override the maximum field size. May be '
                              'necessary for datasets with very wide text '
-                             'fields, but can lead to memory issues. Use '
-                             '`max` for the system maximum value, otherwise '
-                             'specify an integer for the number of bytes.')
+                             'fields, but can lead to memory issues.')
     misc_gr = parser.add_argument_group('Miscellaneous')
     misc_gr.add_argument('-y', '--yes', dest='prompt', action='store_true',
                          help="Always answer 'yes' for user prompts")
@@ -230,22 +228,6 @@ def parse_args(argv, standalone=False):
                    for k, v in vars(parser.parse_args(argv)).items()
                    if v is not None}
     return parsed_args
-
-
-def _parse_field_size_limit(fsl):
-    """Users can either (1) not specify (i.e. will be `None`) in which case
-    we will use the system default, (2) use the string `max` in which case we
-    will use sys.maxsize, or (3) specify an integer for how many bytes a
-    field can take up
-    """
-    if fsl is None:
-        return fsl
-    if fsl == 'max':
-        return sys.maxsize
-    try:
-        return int(fsl)
-    except ValueError:
-        raise ValueError('Invalid value for field_size_limit: {}'.format(fsl))
 
 
 def parse_generic_options(parsed_args):

--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -185,6 +185,12 @@ def parse_args(argv, standalone=False):
                              'keyword "tab" can be used to indicate a tab '
                              'delimited csv. "pipe" can be used to indicate '
                              '"|"')
+    csv_gr.add_argument('--field_size_limit', type=str, default=None,
+                        help='Override the maximum field size. May be '
+                             'necessary for datasets with very wide text fields, '
+                             'but can lead to memory issues. Use `max` for the '
+                             'system maximum value, otherwise specify an integer '
+                             'for the number of bytes.')
     misc_gr = parser.add_argument_group('Miscellaneous')
     misc_gr.add_argument('-y', '--yes', dest='prompt', action='store_true',
                          help="Always answer 'yes' for user prompts")
@@ -226,6 +232,19 @@ def parse_args(argv, standalone=False):
     return parsed_args
 
 
+def _parse_field_size_limit(fsl):
+    """Users can either (1) not specify (i.e. will be `None`) in which case we will use
+    the system default, (2) use the string `max` in which case we will use sys.maxsize,
+    or (3) specify an integer for how many bytes a field can take up
+    """
+    if fsl is None or fsl == 'max':
+        return fsl
+    try:
+        return int(fsl)
+    except ValueError:
+        raise ValueError('Invalid value for field_size_limit: {}'.format(fsl))
+
+
 def parse_generic_options(parsed_args):
     global ui
     loglevel = logging.DEBUG if parsed_args['verbose'] else logging.INFO
@@ -252,6 +271,7 @@ def parse_generic_options(parsed_args):
     skip_dialect = parsed_args['skip_dialect']
     skip_row_id = parsed_args['skip_row_id']
     host = parsed_args.get('host')
+    field_size_limit = parsed_args.get('field_size_limit')
     pred_name = parsed_args.get('pred_name')
     dry_run = parsed_args.get('dry_run', False)
     base_url = ""
@@ -302,6 +322,7 @@ def parse_generic_options(parsed_args):
         'dry_run': dry_run,
         'encoding': encoding,
         'fast_mode': fast_mode,
+        'field_size_limit': field_size_limit,
         'keep_cols': keep_cols,
         'n_retry': n_retry,
         'n_samples': n_samples,

--- a/datarobot_batch_scoring/utils.py
+++ b/datarobot_batch_scoring/utils.py
@@ -54,6 +54,7 @@ config_validator = t.Dict({
     OptKey('pred_name'): t.String,
     OptKey('skip_row_id'): t.Bool,
     OptKey('output_delimiter'): t.String,
+    OptKey('field_size_limit'): t.Int,
 }).allow_extra('*')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import uuid
 import pytest
+import six
 
 from datarobot_batch_scoring.utils import UI
 
@@ -18,3 +19,17 @@ def ui():
     ui = UI(True, 'DEBUG', False)
     yield ui
     ui.close()
+
+
+@pytest.fixture
+def csv_file_handle_with_wide_field():
+    s = six.StringIO()
+    s.write('idx,data\n')
+    s.write('1,one\n')
+    s.write('2,two\n')
+    s.write('3,three\n')
+    s.write('4,')
+    for idx in six.moves.range(50000):
+        s.write('spam{}'.format(idx))
+    s.seek(0)
+    return s

--- a/tests/test_conf_file.py
+++ b/tests/test_conf_file.py
@@ -138,7 +138,8 @@ def test_run_main_with_conf_file(monkeypatch):
                 skip_dialect=False,
                 skip_row_id=False,
                 output_delimiter=None,
-                compression=False
+                compression=False,
+                field_size_limit=None
             )
     finally:
         os.remove(test_file.name)
@@ -197,7 +198,8 @@ def test_run_empty_main_with_conf_file(monkeypatch):
                     skip_dialect=False,
                     skip_row_id=False,
                     output_delimiter=None,
-                    compression=False
+                    compression=False,
+                    field_size_limit=None
                 )
     finally:
         os.remove(test_file.name)

--- a/tests/test_conf_file.py
+++ b/tests/test_conf_file.py
@@ -70,6 +70,19 @@ def test_section_basic_with_username():
         os.remove(test_file.name)
 
 
+def test_field_width_config_option():
+    raw_data = (
+        '[batch_scoring]\n'
+        'field_size_limit=12345678'
+    )
+    with NamedTemporaryFile(suffix='.ini') as test_file:
+        test_file.write(str(raw_data).encode('utf-8'))
+        test_file.file.flush()
+        parsed_result = parse_config_file(test_file.name)
+
+    assert parsed_result['field_size_limit'] == 12345678
+
+
 def test_run_main_with_conf_file(monkeypatch):
     main_args = ['--host',
                  'http://localhost:53646/api',

--- a/tests/test_conf_file.py
+++ b/tests/test_conf_file.py
@@ -75,12 +75,14 @@ def test_field_width_config_option():
         '[batch_scoring]\n'
         'field_size_limit=12345678'
     )
-    with NamedTemporaryFile(suffix='.ini') as test_file:
+    with NamedTemporaryFile(suffix='.ini', delete=False) as test_file:
         test_file.write(str(raw_data).encode('utf-8'))
-        test_file.file.flush()
-        parsed_result = parse_config_file(test_file.name)
 
-    assert parsed_result['field_size_limit'] == 12345678
+    try:
+        parsed_result = parse_config_file(test_file.name)
+        assert parsed_result['field_size_limit'] == 12345678
+    finally:
+        os.remove(test_file.name)
 
 
 def test_run_main_with_conf_file(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,7 +47,8 @@ def test_without_passed_user_and_passwd(monkeypatch):
             skip_dialect=False,
             skip_row_id=False,
             output_delimiter=None,
-            compression=False
+            compression=False,
+            field_size_limit=None,
         )
 
 
@@ -93,7 +94,8 @@ def test_keep_cols(monkeypatch):
             skip_dialect=False,
             skip_row_id=False,
             output_delimiter=None,
-            compression=False
+            compression=False,
+            field_size_limit=None
         )
 
 
@@ -183,7 +185,8 @@ def test_datarobot_key(monkeypatch):
             skip_dialect=False,
             skip_row_id=False,
             output_delimiter=None,
-            compression=False
+            compression=False,
+            field_size_limit=None
         )
 
 
@@ -230,7 +233,8 @@ def test_encoding_options(monkeypatch):
             skip_dialect=True,
             skip_row_id=False,
             output_delimiter=None,
-            compression=False
+            compression=False,
+            field_size_limit=None,
         )
 
 
@@ -316,7 +320,8 @@ def test_output_delimiter(monkeypatch):
             skip_dialect=True,
             skip_row_id=False,
             output_delimiter='\t',
-            compression=False
+            compression=False,
+            field_size_limit=None
         )
 
 
@@ -363,7 +368,8 @@ def test_skip_row_id(monkeypatch):
             skip_dialect=True,
             skip_row_id=True,
             output_delimiter=None,
-            compression=False
+            compression=False,
+            field_size_limit=None
         )
 
 
@@ -407,5 +413,6 @@ def test_datarobot_transferable_call(monkeypatch):
             skip_dialect=False,
             skip_row_id=False,
             output_delimiter=None,
-            compression=False
+            compression=False,
+            field_size_limit=None,
         )

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -17,7 +17,7 @@ class TestCSVReaderWithWideData(object):
     @pytest.yield_fixture
     def really_big_fields_enabled(self):
         old_limit = csv.field_size_limit()
-        csv.field_size_limit(sys.maxsize)
+        csv.field_size_limit(2 ** 28)
         yield
         csv.field_size_limit(old_limit)
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -21,23 +21,35 @@ class TestCSVReaderWithWideData(object):
         yield
         csv.field_size_limit(old_limit)
 
-    def test_slow_reader_with_really_wide_field_fails_default(self, csv_file_handle_with_wide_field):
-        reader = SlowReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
+    def test_slow_reader_with_really_wide_field_fails_default(
+            self, csv_file_handle_with_wide_field):
+        reader = SlowReader(csv_file_handle_with_wide_field,
+                            'utf-8',
+                            ui=Mock())
         with pytest.raises(csv.Error):
             list(reader)
 
     @pytest.mark.usefixtures('really_big_fields_enabled')
-    def test_slow_reader_can_succeed_if_override_csv_width(self, csv_file_handle_with_wide_field):
-        reader = SlowReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
+    def test_slow_reader_can_succeed_if_override_csv_width(
+            self, csv_file_handle_with_wide_field):
+        reader = SlowReader(csv_file_handle_with_wide_field,
+                            'utf-8',
+                            ui=Mock())
         data = list(reader)
         assert len(data) == 4
 
-    def test_fast_reader_with_really_wide_field_cannot_even_instantiate_default(self, csv_file_handle_with_wide_field):
+    def test_fast_reader_with_really_wide_field_wont_even_instantiate_default(
+            self,
+            csv_file_handle_with_wide_field):
         with pytest.raises(csv.Error):
             FastReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
 
     @pytest.mark.usefixtures('really_big_fields_enabled')
-    def test_fast_reader_can_succeed_if_override_csv_width(self, csv_file_handle_with_wide_field):
-        reader = FastReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
+    def test_fast_reader_can_succeed_if_override_csv_width(
+            self,
+            csv_file_handle_with_wide_field):
+        reader = FastReader(csv_file_handle_with_wide_field,
+                            'utf-8',
+                            ui=Mock())
         data = list(reader)
         assert len(data) == 4

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,45 @@
+import csv
+import sys
+
+import pytest
+import six
+import six.moves
+from mock import Mock
+
+from datarobot_batch_scoring.reader import FastReader, SlowReader
+
+
+class TestCSVReaderWithWideData(object):
+
+    @pytest.fixture(autouse=True)
+    def registered_dialect(self):
+        # This was written weird
+        csv.register_dialect('dataset_dialect', csv.excel)
+
+    @pytest.yield_fixture
+    def really_big_fields_enabled(self):
+        old_limit = csv.field_size_limit()
+        csv.field_size_limit(sys.maxsize)
+        yield
+        csv.field_size_limit(old_limit)
+
+    def test_slow_reader_with_really_wide_field_fails_default(self, csv_file_handle_with_wide_field):
+        reader = SlowReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
+        with pytest.raises(csv.Error):
+            list(reader)
+
+    @pytest.mark.usefixtures('really_big_fields_enabled')
+    def test_slow_reader_can_succeed_if_override_csv_width(self, csv_file_handle_with_wide_field):
+        reader = SlowReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
+        data = list(reader)
+        assert len(data) == 4
+
+    def test_fast_reader_with_really_wide_field_cannot_even_instantiate_default(self, csv_file_handle_with_wide_field):
+        with pytest.raises(csv.Error):
+            FastReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
+
+    @pytest.mark.usefixtures('really_big_fields_enabled')
+    def test_fast_reader_can_succeed_if_override_csv_width(self, csv_file_handle_with_wide_field):
+        reader = FastReader(csv_file_handle_with_wide_field, 'utf-8', ui=Mock())
+        data = list(reader)
+        assert len(data) == 4

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,5 +1,4 @@
 import csv
-import sys
 
 import pytest
 from mock import Mock

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2,8 +2,6 @@ import csv
 import sys
 
 import pytest
-import six
-import six.moves
 from mock import Mock
 
 from datarobot_batch_scoring.reader import FastReader, SlowReader


### PR DESCRIPTION
By specifying a value for csv.field_size_limit, we can overcome the
arbitary limit imposed by the csv module.

- [x] I think I need another test that it works when strung all together.
- [x] I also need to make sure that you can specify this value in the config.