### PR TITLE
Error messaging for incorrect encoding when using fast_mode [PRED-1095]

### DIFF
--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -364,6 +364,17 @@ def main(argv=sys.argv[1:]):
         ui.error(str(e))
     except KeyboardInterrupt:
         ui.info('Keyboard interrupt')
+    except UnicodeDecodeError as e:
+        ui.error(str(e))
+        if generic_opts.get('fast_mode'):
+            ui.error(
+                'You are using --fast option, which uses a small sample of '
+                'data to figuring out the encoding of your file. You can '
+                'try to specify the encoding directly for this file by using '
+                'the encoding flag (e.g. --encoding utf-8). You could also '
+                'try to remove the --fast mode to auto-detect the encoding '
+                'with a larger sample size'
+            )
     except Exception as e:
         ui.fatal(str(e))
     finally:

--- a/datarobot_batch_scoring/main.py
+++ b/datarobot_batch_scoring/main.py
@@ -367,14 +367,12 @@ def main(argv=sys.argv[1:]):
     except UnicodeDecodeError as e:
         ui.error(str(e))
         if generic_opts.get('fast_mode'):
-            ui.error(
-                'You are using --fast option, which uses a small sample of '
-                'data to figuring out the encoding of your file. You can '
-                'try to specify the encoding directly for this file by using '
-                'the encoding flag (e.g. --encoding utf-8). You could also '
-                'try to remove the --fast mode to auto-detect the encoding '
-                'with a larger sample size'
-            )
+            ui.error("You are using --fast option, which uses a small sample "
+                     "of data to figuring out the encoding of your file. You "
+                     "can try to specify the encoding directly for this file "
+                     "by using the encoding flag (e.g. --encoding utf-8). "
+                     "You could also try to remove the --fast mode to auto-"
+                     "detect the encoding with a larger sample size")
     except Exception as e:
         ui.fatal(str(e))
     finally:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -234,6 +234,61 @@ def test_encoding_options(monkeypatch):
         )
 
 
+def test_unicode_decode_error_message_fast(monkeypatch):
+    main_args = ['--host',
+                 'http://localhost:53646/api',
+                 '56dd9570018e213242dfa93c',
+                 '56dd9570018e213242dfa93d',
+                 'tests/fixtures/temperatura_predict.csv',
+                 '--encoding=ascii', '--fast', '--dry_run']
+
+    ui_class = mock.Mock(spec=UI)
+    ui = ui_class.return_value
+    monkeypatch.setattr('datarobot_batch_scoring.main.UI', ui_class)
+
+    with mock.patch(
+            'datarobot_batch_scoring.main'
+            '.run_batch_predictions') as mock_method:
+        mock_method.side_effect = UnicodeDecodeError('test',
+                                                     b'', 1, 1, 'test')
+        assert main(argv=main_args) == 1
+
+    ui.error.assert_has_calls([
+        mock.call("'test' codec can't decode bytes in position 1-0: test"),
+        mock.call("You are using --fast option, which uses a small sample "
+                  "of data to figuring out the encoding of your file. You "
+                  "can try to specify the encoding directly for this file "
+                  "by using the encoding flag (e.g. --encoding utf-8). "
+                  "You could also try to remove the --fast mode to auto-"
+                  "detect the encoding with a larger sample size")
+    ])
+
+
+def test_unicode_decode_error_message_slow(monkeypatch):
+    main_args = ['--host',
+                 'http://localhost:53646/api',
+                 '56dd9570018e213242dfa93c',
+                 '56dd9570018e213242dfa93d',
+                 'tests/fixtures/temperatura_predict.csv',
+                 '--dry_run']
+
+    ui_class = mock.Mock(spec=UI)
+    ui = ui_class.return_value
+    monkeypatch.setattr('datarobot_batch_scoring.main.UI', ui_class)
+
+    with mock.patch(
+            'datarobot_batch_scoring.main'
+            '.run_batch_predictions') as mock_method:
+        mock_method.side_effect = UnicodeDecodeError('test',
+                                                     b'', 1, 1, 'test')
+        assert main(argv=main_args) == 1
+
+    # Without fast flag, we don't show the verbose error message
+    ui.error.assert_called_with(
+        "'test' codec can't decode bytes in position 1-0: test"
+    )
+
+
 def test_invalid_delimiter(monkeypatch):
     main_args = ['--host',
                  'http://localhost:53646/api',


### PR DESCRIPTION
Example of the new error message in action.
```
MainProcess [ERROR] 'ascii' codec can't decode byte 0xc2 in position 348134: ordinal not in range(128)
MainProcess [ERROR] You are using --fast option, which uses a small sample of data to figuring out the encoding of your file. You can try to specify the encoding directly for this file by using the encoding flag (e.g. --encoding utf-8). You could also try to remove the --fast mode to auto-detect the encoding with a larger sample
```