### PR TITLE
Pred 1587 random quit

### DIFF
--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -85,7 +85,7 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
                                            concurrent)
 
     with ExitStack() as stack:
-        if os.name is 'nt':
+        if os.name == 'nt':
             #  Windows requires an additional manager process. The locks
             #  and queues it creates are proxies for objects that exist within
             #  the manager itself. It does not perform as well so we only
@@ -575,7 +575,7 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
             ui.debug('Network finished with error')
             exit_code = 1
 
-        if writer_exitcode is 0:
+        if writer_exitcode == 0:
             ui.debug('writer process exited successfully')
         else:
             ui.debug('writer process did not exit properly: '
@@ -634,7 +634,7 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
 
         ui.info('==== Total stats ===='.format(bucket))
         ui.info("done: {} lost: {}".format(total_done, total_lost))
-        if exit_code is None and total_lost is 0:
+        if exit_code is None and total_lost == 0:
             ctx.scoring_succeeded = True
         else:
             exit_code = 1

--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -53,6 +53,15 @@ def format_usage(rusage):
                "RSS: {rss}".format(**rusage)
 
 
+def my_os_cannot_handle_life_in_the_fast_lane():
+    if os.name == 'nt':
+        return True
+    elif platform.system() == 'Darwin' and sys.version_info >= (3, 6):
+        return True
+    else:
+        return False
+
+
 def run_batch_predictions(base_url, base_headers, user, pwd,
                           api_token, create_api_token,
                           pid, lid, import_id, n_retry, concurrent,
@@ -85,7 +94,7 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
                                            concurrent)
 
     with ExitStack() as stack:
-        if os.name == 'nt':
+        if my_os_cannot_handle_life_in_the_fast_lane():
             #  Windows requires an additional manager process. The locks
             #  and queues it creates are proxies for objects that exist within
             #  the manager itself. It does not perform as well so we only
@@ -252,7 +261,6 @@ def run_batch_predictions(base_url, base_headers, user, pwd,
                                               ))
 
         exit_code = None
-
         writer = stack.enter_context(WriterProcess(ui, ctx, writer_queue,
                                                    network_queue,
                                                    network_deque,

--- a/datarobot_batch_scoring/network/network.py
+++ b/datarobot_batch_scoring/network/network.py
@@ -6,28 +6,26 @@ import signal
 import textwrap
 from functools import partial
 from time import time
-
-import requests
-import requests.adapters
 from concurrent.futures import FIRST_COMPLETED
 from concurrent.futures import wait
-from datarobot_batch_scoring.consts import (SENTINEL,
-                                            REPORT_INTERVAL,
-                                            ProgressQueueMsg, WriterQueueMsg)
-from datarobot_batch_scoring.utils import get_rusage
-from six.moves import queue
-
-from .base_network_worker import BaseNetworkWorker
-
 try:
     from futures import ThreadPoolExecutor
 except ImportError:
     from concurrent.futures import ThreadPoolExecutor
 
+from six.moves import queue
+import requests
+import requests.adapters
+
+from datarobot_batch_scoring.consts import (SENTINEL,
+                                            REPORT_INTERVAL,
+                                            ProgressQueueMsg, WriterQueueMsg)
+from datarobot_batch_scoring.utils import get_rusage
+
+from .base_network_worker import BaseNetworkWorker
+
 
 logger = logging.getLogger(__name__)
-
-
 FakeResponse = collections.namedtuple('FakeResponse', 'status_code, text')
 
 

--- a/datarobot_batch_scoring/network/network.py
+++ b/datarobot_batch_scoring/network/network.py
@@ -101,8 +101,8 @@ class Network(BaseNetworkWorker):
 
     def _request(self, request):
 
-        prepared = self.session.prepare_request(request)
         try:
+            prepared = self.session.prepare_request(request)
             self.session.send(prepared, timeout=self._timeout)
         except Exception as exc:
             code = 400


### PR DESCRIPTION
Greg Michaelson reported that on an OSX laptop running python 3.6, batch_scoring falls over with no error message.

The fix is to run the code in that environment with more safety restrictions. The safest seems to be to use the `multiprocessing.SyncManager`.