### PR TITLE
Monkey patch

### DIFF
--- a/datarobot_batch_scoring/batch_scoring.py
+++ b/datarobot_batch_scoring/batch_scoring.py
@@ -56,8 +56,6 @@ def format_usage(rusage):
 def my_os_cannot_handle_life_in_the_fast_lane():
     if os.name == 'nt':
         return True
-    elif platform.system() == 'Darwin' and sys.version_info >= (3, 6):
-        return True
     else:
         return False
 

--- a/datarobot_batch_scoring/network/network.py
+++ b/datarobot_batch_scoring/network/network.py
@@ -44,14 +44,14 @@ except ImportError:
         if no_args:
             # We were called without args
             func = setting_args[0]
-        def outer(method):
-            @functools.wraps(method)
-            def func(*args, **kwargs):
+        def outer(func):
+            @functools.wraps(func)
+            def cacher(*args, **kwargs):
                 key = tuple(args) + tuple(sorted(kwargs.items()))
                 if key not in cache:
                     cache[key] = method(*args, **kwargs)
                 return cache[key]
-            return func
+            return cacher
         return outer(func) if no_args else outer
 
 

--- a/datarobot_batch_scoring/network/network.py
+++ b/datarobot_batch_scoring/network/network.py
@@ -49,7 +49,7 @@ except ImportError:
             def cacher(*args, **kwargs):
                 key = tuple(args) + tuple(sorted(kwargs.items()))
                 if key not in cache:
-                    cache[key] = method(*args, **kwargs)
+                    cache[key] = func(*args, **kwargs)
                 return cache[key]
             return cacher
         return outer(func) if no_args else outer

--- a/datarobot_batch_scoring/network/network.py
+++ b/datarobot_batch_scoring/network/network.py
@@ -109,12 +109,10 @@ class Network(BaseNetworkWorker):
                               'because of FakeResponse')
             else:
                 try:
-                    self.ui.warning('batch {} failed with status code '
-                                    '{} message: {}'
-                                    ''.format(
-                                         batch.id,
-                                         r.status_code,
-                                         json.loads(r.text)['message']))
+                    fmt = 'batch {} failed with status code {} message: {}'
+                    self.ui.warning(
+                        fmt.format(batch.id, r.status_code, json.loads(r.text)['message'])
+                    )
                 except ValueError:
                     self.ui.warning('batch {} failed with status code: {}'
                                     ''.format(batch.id, r.status_code))

--- a/datarobot_batch_scoring/network/network.py
+++ b/datarobot_batch_scoring/network/network.py
@@ -49,11 +49,10 @@ except ImportError:
         def outer(func):
             @functools.wraps(func)
             def cacher(*args, **kwargs):
-                with lock:
-                    key = tuple(args) + tuple(sorted(kwargs.items()))
-                    if key not in cache:
-                        cache[key] = func(*args, **kwargs)
-                    return cache[key]
+                key = tuple(args) + tuple(sorted(kwargs.items()))
+                if key not in cache:
+                    cache[key] = func(*args, **kwargs)
+                return cache[key]
             return cacher
         return outer(func) if no_args else outer
 
@@ -78,7 +77,8 @@ old_getaddrinfo = r_socket.getaddrinfo
 
 @lru_cache()
 def my_getaddrinfo(*args, **kwargs):
-    return old_getaddrinfo(*args, **kwargs)
+    with lock:
+        return old_getaddrinfo(*args, **kwargs)
 
 r_socket.getaddrinfo = my_getaddrinfo
 

--- a/datarobot_batch_scoring/utils.py
+++ b/datarobot_batch_scoring/utils.py
@@ -419,6 +419,7 @@ def make_validation_call(user, api_token, n_retry, endpoint, base_headers,
     else:
         ui.debug('authorization has succeeded')
 
+
 try:
     import resource
 


### PR DESCRIPTION
https://datarobot.atlassian.net/browse/PRED-1587 implemented a quick hack to address a failure in batch-scoring. This code addresses the problem more directly.

The code needs to be tested in python 2.7 and python 3.x because there is a use of a python 3.x library function (`functools.lru_cache`) that has no backport in python 2.7, so I provided an implementation. I will merge only after local tests show it working in both python environments with various numbers of concurrent thread counts.