### PR TITLE
Use exit codes from PyInstaller entrypoint [PRED-1736]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Enhancements
   Check ``batch_scoring --help`` for a list of valid options and the default value.
 * Default for timeout is now None, meaning that the code does not enforce a timeout for operations to the server. This allows completion of runs with higher numbers of threads, particularly in MacOS. The value remains modifiable, and 30 seconds is a reasonable value in most cases.
 
+Bugfixes
+--------
+* An issue which caused exit codes to not be set correctly from executables installed via the standalone installer
+  has been addressed. The exit codes will now be set correctly.
+
 1.12.1 (2017 August 14)
 =======================
 

--- a/batch_scoring.py
+++ b/batch_scoring.py
@@ -1,4 +1,6 @@
+import sys
+
 from datarobot_batch_scoring import main
 # This exists as a simple entrypoint for PyInstaller
 
-main.main()
+sys.exit(main.main())

--- a/batch_scoring_sse.py
+++ b/batch_scoring_sse.py
@@ -1,4 +1,6 @@
+import sys
+
 from datarobot_batch_scoring import main
 # This exists as a simple entrypoint for PyInstaller
 
-main.main_standalone()
+sys.exit(main.main_standalone())


### PR DESCRIPTION
For executables installed with PyInstaller (i.e. our standalone installer)
the exit code was not being set correctly. This change will correct that
so its behavior is in line with the entrypoint created by setup.py