### PR TITLE
[PRED-1785] Use t.StrBool() for config booleans

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Bugfixes
 --------
 * An issue which caused exit codes to not be set correctly from executables installed via the standalone installer
   has been addressed. The exit codes will now be set correctly.
+* An issue which caused script crashes if one or more boolean options were specified in the config file.
 
 1.12.1 (2017 August 14)
 =======================

--- a/datarobot_batch_scoring/utils.py
+++ b/datarobot_batch_scoring/utils.py
@@ -54,11 +54,11 @@ config_validator = t.Dict({
     OptKey('api_token'): t.String,
     OptKey('create_api_token'): t.String,
     OptKey('pred_name'): t.String,
-    OptKey('skip_row_id'): t.Bool,
+    OptKey('skip_row_id'): t.StrBool,
     OptKey('output_delimiter'): t.String,
     OptKey('field_size_limit'): t.Int,
     OptKey('ca_bundle'): t.String,
-    OptKey('no_verify_ssl'): t.Bool,
+    OptKey('no_verify_ssl'): t.StrBool,
 }).allow_extra('*')
 
 

--- a/tests/test_conf_file.py
+++ b/tests/test_conf_file.py
@@ -1,5 +1,6 @@
 import os
 import mock
+import pytest
 from tempfile import NamedTemporaryFile
 import textwrap
 from datarobot_batch_scoring.utils import (get_config_file,
@@ -70,7 +71,7 @@ def test_section_basic_with_username():
         os.remove(test_file.name)
 
 
-def test_field_width_config_option():
+def test_field_with_config_option():
     raw_data = (
         '[batch_scoring]\n'
         'field_size_limit=12345678'
@@ -83,6 +84,24 @@ def test_field_width_config_option():
         assert parsed_result['field_size_limit'] == 12345678
     finally:
         os.remove(test_file.name)
+
+
+@pytest.mark.parametrize('str_value, bool_value', [
+    ('1', True),
+    ('0', False),
+    ('yes', True),
+    ('no', False),
+    ('true', True),
+    ('false', False),
+])
+def test_field_with_boolean_option(tmpdir, str_value, bool_value):
+    tmpdir.join('test.ini').write_text(
+        u'[batch_scoring]\nskip_row_id=%s' % str_value, 'utf-8')
+
+    conf = parse_config_file(tmpdir.join('test.ini').strpath)
+
+    assert isinstance(conf['skip_row_id'], bool)
+    assert conf['skip_row_id'] == bool_value
 
 
 def test_run_main_with_conf_file(monkeypatch):


### PR DESCRIPTION
ConfigParser doesn't understand types, and everything it reads has str
type out of box. That means all booleans we read a failed to go through
Trafaret validation, because it expects booleans. Fortunately, Trafaret
provides so called StrBool() type that expects string as input, and
produce boolean as output. So let's use it in order to do not crash
reading boolean options from config.

PRED-1785