### PR TITLE
API-3873 remove pymongo dependency as unused one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ install:
 - if [ $TRAVIS_OS_NAME == 'osx' ]; then git clone https://github.com/MacPython/terryfy;
   source terryfy/travis_tools.sh; get_python_environment  $pydist $pyver; fi
 - pip install -U pip wheel
-- pip install -Ur requirements.txt
-- pip install -Ur requirements-test.txt
+- pip install -r requirements.txt
+- pip install -r requirements-test.txt
 - pip install coveralls
 script:
 - if [ $TRAVIS_OS_NAME == 'osx' ]; then ulimit -n 2048; fi

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,5 @@ docutils==0.12
 pytest==2.9.0
 pytest-cov==2.2.1
 pytest-flake8==0.1
-pymongo==2.8
 Flask==0.10.1
 mock>=1.3.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,5 @@ docutils==0.12
 pytest==2.9.0
 pytest-cov==2.2.1
 pytest-flake8==0.1
-pymongo==3.5.1
 Flask==0.10.1
 mock>=1.3.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,6 @@ docutils==0.12
 pytest==2.9.0
 pytest-cov==2.2.1
 pytest-flake8==0.1
+pymongo==3.5.1
 Flask==0.10.1
 mock>=1.3.0


### PR DESCRIPTION
## Rationale
Removed pymongo dependency from test requirements as its not used

## Tests
All test were green on local machine after this change

## Jira
https://datarobot.atlassian.net/browse/API-3873 