### PR TITLE
[API-4184] Do not install "futures" in case of Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+1.13.1 (unreleased)
+===================
+
+Bugfixes
+--------
+* Fix package installation in Python 3 environments.
+
 1.13.0 (2017 November 10)
 =========================
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import sys
 import codecs
 import os.path
 import re
@@ -11,6 +12,24 @@ fname = os.path.join(os.path.abspath(os.path.dirname(
     __file__)), 'requirements.txt')
 
 install_requires = open(fname, 'r').readlines()
+
+# Since futures 3.2 [1], the package enforces to be installed only in Python 2
+# environments because it's basically a backport of Python 3's built-in
+# package. So in order to support both Python 2 and Python 3 environments, we
+# have to skip installation of futures package in case of Python 3.
+#
+# It might look natural to use environment markers [2] to achieve this goal but
+# they are new and were introduced in setuptools in mid of 2017. FWIW,
+# setuptools on both Ubuntu Trusty and Ubuntu Xenial do not support them and
+# batch scoring script may be installed in pretty outdated envs. So let's do it
+# old-fashioned way by adding condition here.
+#
+# [1] https://github.com/agronholm/pythonfutures/commit/d0393ad626d25622927bb0ed47d35ddb2f6cd321
+# [2] https://www.python.org/dev/peps/pep-0508/#environment-markers
+if sys.version_info[0] > 2:
+    install_requires = [req
+                        for req in install_requires
+                        if not req.startswith('futures')]
 
 extra['entry_points'] = {
     'console_scripts': [


### PR DESCRIPTION
Since futures 3.2 [1], the package enforces to be installed only in Python 2
environments because it's basically a backport of Python 3's built-in
package. So in order to support both Python 2 and Python 3 environments, we
have to skip installation of futures package in case of Python 3.

It might look natural to use environment markers [2] to achieve this goal but
they are new and were introduced in setuptools in mid of 2017. FWIW,
setuptools on both Ubuntu Trusty and Ubuntu Xenial do not support them and
batch scoring script may be installed in pretty outdated envs. So let's do it
old-fashioned way by adding condition in setup.py.

[1] https://github.com/agronholm/pythonfutures/commit/d0393ad626d25622927bb0ed47d35ddb2f6cd321
[2] https://www.python.org/dev/peps/pep-0508/#environment-markers

Jira: API-4184