### PR TITLE
Exclude caniusepython3 badge from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,6 @@ A script to score CSV files via DataRobot's prediction API.
 .. image:: https://travis-ci.org/datarobot/batch-scoring.svg?branch=master
     :target: https://travis-ci.org/datarobot/batch-scoring#master
 
-.. image:: https://caniusepython3.com/project/datarobot_batch_scoring.svg
-
 .. image:: https://badge.fury.io/py/datarobot_batch_scoring.svg
     :target: https://pypi.python.org/pypi/datarobot_batch_scoring
 


### PR DESCRIPTION
In #126 @tnekdatarobot noticed that caniusepython3 badge is not displayed properly.

While trying to fix the link, I noticed several issues with that service:

1. Response code was 500
  ```
  $ curl https://caniusepython3.com/project/datarobot_batch_scoring.svg -v
  *   Trying 52.30.21.13...
  * TCP_NODELAY set
  * Connected to caniusepython3.com (52.30.21.13) port 443 (#0)
  * ALPN, offering h2
  * ALPN, offering http/1.1
  * successfully set certificate verify locations:
  *   CAfile: /etc/ssl/certs/ca-certificates.crt
    CApath: none
    * TLSv1.2 (OUT), TLS handshake, Client hello (1):
    * TLSv1.2 (IN), TLS handshake, Server hello (2):
    * TLSv1.2 (IN), TLS handshake, Certificate (11):
    * TLSv1.2 (IN), TLS handshake, Server key exchange (12):
    * TLSv1.2 (IN), TLS handshake, Server finished (14):
    * TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
    * TLSv1.2 (OUT), TLS change cipher, Client hello (1):
    * TLSv1.2 (OUT), TLS handshake, Finished (20):
    * TLSv1.2 (IN), TLS handshake, Finished (20):
    * SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
    * ALPN, server accepted to use h2
    * Server certificate:
    *  subject: CN=caniusepython3.com
    *  start date: Mar 31 11:38:28 2018 GMT
    *  expire date: Jun 29 11:38:28 2018 GMT
    *  subjectAltName: host "caniusepython3.com" matched cert's
  "caniusepython3.com"
  *  issuer: C=US; O=Let's Encrypt; CN=Let's Encrypt Authority X3
  *  SSL certificate verify ok.
  * Using HTTP2, server supports multi-use
  * Connection state changed (HTTP/2 confirmed)
  * Copying HTTP/2 data in stream buffer to connection buffer after
  upgrade: len=0
  * Using Stream ID: 1 (easy handle 0x559df403f080)
  > GET /project/datarobot_batch_scoring.svg HTTP/2
  > Host: caniusepython3.com
  > User-Agent: curl/7.60.0
  > Accept: */*
  >
  * Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
  < HTTP/2 500
  < server: nginx
  < date: Mon, 18 Jun 2018 12:20:29 GMT
  < content-type: text/html; charset=utf-8
  < x-content-type-options: nosniff
  < vary: Cookie
  < x-xss-protection: 1; mode=block
  <
  * Connection #0 to host caniusepython3.com left intact
  <h1>Server Error (500)</h1>%
  ```
2. About page doesn't exist (even though it's included into footer)
  ```
  $ curl https://caniusepython3.com/about/ -v
  *   Trying 52.30.21.13...
  * TCP_NODELAY set
  * Connected to caniusepython3.com (52.30.21.13) port 443 (#0)
  * ALPN, offering h2
  * ALPN, offering http/1.1
  * successfully set certificate verify locations:
  *   CAfile: /etc/ssl/certs/ca-certificates.crt
    CApath: none
    * TLSv1.2 (OUT), TLS handshake, Client hello (1):
    * TLSv1.2 (IN), TLS handshake, Server hello (2):
    * TLSv1.2 (IN), TLS handshake, Certificate (11):
    * TLSv1.2 (IN), TLS handshake, Server key exchange (12):
    * TLSv1.2 (IN), TLS handshake, Server finished (14):
    * TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
    * TLSv1.2 (OUT), TLS change cipher, Client hello (1):
    * TLSv1.2 (OUT), TLS handshake, Finished (20):
    * TLSv1.2 (IN), TLS handshake, Finished (20):
    * SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
    * ALPN, server accepted to use h2
    * Server certificate:
    *  subject: CN=caniusepython3.com
    *  start date: Mar 31 11:38:28 2018 GMT
    *  expire date: Jun 29 11:38:28 2018 GMT
    *  subjectAltName: host "caniusepython3.com" matched cert's
  "caniusepython3.com"
  *  issuer: C=US; O=Let's Encrypt; CN=Let's Encrypt Authority X3
  *  SSL certificate verify ok.
  * Using HTTP2, server supports multi-use
  * Connection state changed (HTTP/2 confirmed)
  * Copying HTTP/2 data in stream buffer to connection buffer after
  upgrade: len=0
  * Using Stream ID: 1 (easy handle 0x55af122ad080)
  > GET /about/ HTTP/2
  > Host: caniusepython3.com
  > User-Agent: curl/7.60.0
  > Accept: */*
  >
  * Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
  < HTTP/2 404
  < server: nginx
  < date: Mon, 18 Jun 2018 12:21:40 GMT
  < content-type: text/html; charset=utf-8
  < vary: Accept-Encoding
  < x-content-type-options: nosniff
  < x-xss-protection: 1; mode=block
  <
  * Connection #0 to host caniusepython3.com left intact
  <h1>Not Found</h1><p>The requested URL /about/ was not found on this server.</p>%
  ```
3. Redirect from http to https doesn't work properly (`Location: https:///`)
  ```
  $ curl http://caniusepython3.com/ -v
  *   Trying 52.30.21.13...
  * TCP_NODELAY set
  * Connected to caniusepython3.com (52.30.21.13) port 80 (#0)
  > GET / HTTP/1.1
  > Host: caniusepython3.com
  > User-Agent: curl/7.60.0
  > Accept: */*
  >
  < HTTP/1.1 301 Moved Permanently
  < Server: nginx
  < Date: Mon, 18 Jun 2018 12:23:00 GMT
  < Content-Type: text/html
  < Content-Length: 178
  < Connection: keep-alive
  < Location: https:///
  < X-Frame-Options: SAMEORIGIN
  < X-Content-Type-Options: nosniff
  < X-XSS-Protection: 1; mode=block
  <
  <html>
  <head><title>301 Moved Permanently</title></head>
  <body bgcolor="white">
  <center><h1>301 Moved Permanently</h1></center>
  <hr><center>nginx</center>
  </body>
  </html>
  * Connection #0 to host caniusepython3.com left intact
  ```

I don't trust this service enough now, so I'm just removing the badge. I don't think we need a replacement.