### PR TITLE
Use curl instead of wget in Dockerfile-pyinstaller-centos5-py35-build

### DIFF
--- a/Dockerfile-pyinstaller-centos5-py35-build
+++ b/Dockerfile-pyinstaller-centos5-py35-build
@@ -18,8 +18,8 @@ ENV PYTHON_VERSION 3.5.3
 
 RUN set -ex \
     && yum install -y xz gpg zip openssl-devel zlib-devel bzip2-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel \
-	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
-	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& curl -o python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& curl -o python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
 	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \


### PR DESCRIPTION
`wget` shipped in manylinux is linked against system-wide OpenSSL0.9.8, so it doesn't support TLS 1.2 (which is now used by Python infrastructure).

`curl` is statically linked against OpenSSL 1.0.2o.

Please see [pypa/manylinux#202][1] for more details.

[1]: https://github.com/pypa/manylinux/issues/202